### PR TITLE
feat: prettierとeslintの設定

### DIFF
--- a/.github/workflows/front.yml
+++ b/.github/workflows/front.yml
@@ -1,0 +1,21 @@
+name: front
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - uses: actions/cache@v3
+        id: cache_node_modules
+        with:
+          path: "**/node_modules"
+          key: node_modules-${{ hashFiles('**/package.json', 'yarn.lock') }}
+      - run: yarn install --frozen-lockfile
+        if: steps.cache_node_modules.outputs.cache-hit != 'true'
+      - run: yarn prettier --check './src/**/*.{ts,tsx,js}'
+      - run: yarn eslint './src/**/*.{ts,tsx,js}'
+      - run: yarn build

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 120
+semi: false

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,7 @@
 const { FlatCompat } = require("@eslint/eslintrc")
 const prettier = require("eslint-config-prettier")
+const ts = require("@typescript-eslint/eslint-plugin")
+const tsParser = require("@typescript-eslint/parser")
 
 const compat = new FlatCompat()
 
@@ -12,6 +14,19 @@ module.exports = [
     },
   },
   {
-    files: ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"],
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      parser: tsParser,
+    },
+    plugins: {
+      "@typescript-eslint": ts,
+    },
+    rules: {
+      ...ts.configs["recommended"].rules,
+      ...ts.configs["eslint-recommended"].rules,
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    },
   },
 ]

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,18 @@ module.exports = [
     rules: {
       ...prettier.rules,
       "react/display-name": "off",
+      "import/order": [
+        "error",
+        {
+          "newlines-between": "always",
+          groups: ["builtin", "external", "internal", ["parent", "sibling"], "index"],
+          alphabetize: {
+            order: "asc",
+            caseInsensitive: true,
+          },
+        },
+      ],
+      "import/no-duplicates": "error",
     },
   },
   {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,17 @@
+const { FlatCompat } = require("@eslint/eslintrc")
+const prettier = require("eslint-config-prettier")
+
+const compat = new FlatCompat()
+
+module.exports = [
+  ...compat.extends("next/core-web-vitals"),
+  {
+    rules: {
+      ...prettier.rules,
+      "react/display-name": "off",
+    },
+  },
+  {
+    files: ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"],
+  },
+]

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "prettier --check . && next lint",
+    "lint:fix": "prettier --write . && next lint --fix"
   },
   "dependencies": {
     "@emoji-mart/data": "^1.0.8",
@@ -39,5 +40,8 @@
     "react-ionicons": "^4.2.0",
     "styled-components": "^5.3.6",
     "typescript": "4.8.4"
+  },
+  "devDependencies": {
+    "prettier": "^2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "prettier --check . && next lint",
-    "lint:fix": "prettier --write . && next lint --fix"
+    "lint": "prettier --check './**/*.{ts,tsx,js}' && eslint './src/**/*.{ts,tsx,js}'",
+    "lint:fix": "prettier --write './src/**/*.{ts,tsx,js}' && eslint --fix './src/**/*.{ts,tsx,js}'"
   },
   "dependencies": {
     "@emoji-mart/data": "^1.0.8",
@@ -42,6 +42,7 @@
     "typescript": "4.8.4"
   },
   "devDependencies": {
+    "eslint-config-prettier": "^8.5.0",
     "prettier": "^2.8.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "typescript": "4.8.4"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.46.0",
+    "@typescript-eslint/parser": "^5.46.0",
     "eslint-config-prettier": "^8.5.0",
     "prettier": "^2.8.1"
   }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
     "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-import": "^2.26.0",
     "prettier": "^2.8.1"
   }
 }

--- a/src/components/DocumentCard.tsx
+++ b/src/components/DocumentCard.tsx
@@ -1,20 +1,16 @@
-import { Card, Box, Text } from "@mantine/core";
-import React, { memo } from "react";
+import { Card, Box, Text } from "@mantine/core"
+import React, { memo } from "react"
 
 interface Props {
-  emoji: string;
-  title: string;
-  name: string;
+  emoji: string
+  title: string
+  name: string
 }
 
 export const DocumentCard: React.FC<Props> = memo(({ emoji, title, name }) => {
   return (
     <Card shadow="sm" p="md" radius="md" sx={{ width: "160px" }}>
-      <Card.Section
-        bg="indigo.0"
-        p="lg"
-        sx={{ justifyContent: "center", display: "flex" }}
-      >
+      <Card.Section bg="indigo.0" p="lg" sx={{ justifyContent: "center", display: "flex" }}>
         <Text span fz="50px">
           {emoji}
         </Text>
@@ -26,5 +22,5 @@ export const DocumentCard: React.FC<Props> = memo(({ emoji, title, name }) => {
         </Text>
       </Box>
     </Card>
-  );
-});
+  )
+})

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,5 +1,5 @@
-import React, { memo, PropsWithChildren } from "react"
 import { Text } from "@mantine/core"
+import React, { memo, PropsWithChildren } from "react"
 
 interface Props {
   as?: string

--- a/src/components/PageTitle.tsx
+++ b/src/components/PageTitle.tsx
@@ -1,12 +1,10 @@
-import React, { memo, PropsWithChildren } from "react";
-import { Text } from "@mantine/core";
+import React, { memo, PropsWithChildren } from "react"
+import { Text } from "@mantine/core"
 
 interface Props {
-  as?: string;
+  as?: string
 }
 
-export const PageTitle: React.FC<PropsWithChildren<Props>> = memo(
-  ({ children, as = "h1" }) => {
-    return <Text component={as as any}>{children}</Text>;
-  }
-);
+export const PageTitle: React.FC<PropsWithChildren<Props>> = memo(({ children, as = "h1" }) => {
+  return <Text component={as as any}>{children}</Text>
+})

--- a/src/components/system/Spacer.tsx
+++ b/src/components/system/Spacer.tsx
@@ -1,5 +1,5 @@
-import React, { memo } from "react";
-import { Box } from "@mantine/core";
+import React, { memo } from "react"
+import { Box } from "@mantine/core"
 
 export const Spacer = memo(() => {
   return (
@@ -10,5 +10,5 @@ export const Spacer = memo(() => {
         placeSelf: "stretch",
       }}
     ></Box>
-  );
-});
+  )
+})

--- a/src/components/system/Spacer.tsx
+++ b/src/components/system/Spacer.tsx
@@ -1,5 +1,5 @@
-import React, { memo } from "react"
 import { Box } from "@mantine/core"
+import React, { memo } from "react"
 
 export const Spacer = memo(() => {
   return (

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,6 @@
-export const APP_NAME = "つながるLT";
+export const APP_NAME = "つながるLT"
 
 export const CONTENTFUL_BASE_INFO = {
   space: "9hz28zmw3cm1",
   environment: "master",
-};
+}

--- a/src/features/Footer/index.tsx
+++ b/src/features/Footer/index.tsx
@@ -1,8 +1,10 @@
-import { Footer } from '@mantine/core'
-import React, { memo } from 'react'
+import { Footer } from "@mantine/core"
+import React, { memo } from "react"
 
 export const AppFooter = memo(() => {
-    return (
-      <Footer height={60} p="xs">AppFooter</Footer>
-    )
-  })
+  return (
+    <Footer height={60} p="xs">
+      AppFooter
+    </Footer>
+  )
+})

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -1,13 +1,13 @@
-import { Text } from "@mantine/core";
-import React, { memo } from "react";
-import { Header } from '@mantine/core';
+import { Text } from "@mantine/core"
+import React, { memo } from "react"
+import { Header } from "@mantine/core"
 
 export const AppHeader = memo(() => {
   return (
-    <Header  height={60} p="xs">
+    <Header height={60} p="xs">
       <Text component="h1" sx={{ fontFamily: "Mona Sans" }}>
         つながるLT
       </Text>
     </Header>
-  );
-});
+  )
+})

--- a/src/features/Header/index.tsx
+++ b/src/features/Header/index.tsx
@@ -1,6 +1,5 @@
-import { Text } from "@mantine/core"
+import { Text, Header } from "@mantine/core"
 import React, { memo } from "react"
-import { Header } from "@mantine/core"
 
 export const AppHeader = memo(() => {
   return (

--- a/src/features/documents/api/createDocument.ts
+++ b/src/features/documents/api/createDocument.ts
@@ -1,14 +1,12 @@
-import { useMutation, UseMutationOptions } from "@tanstack/react-query";
-import { axios } from "@/lib/axios";
-import { DocumentDetailCreateRequest } from "../types";
-import { BaseResponse } from "@/types";
-import toast from "react-hot-toast";
-import { AxiosResponse } from "axios";
+import { useMutation, UseMutationOptions } from "@tanstack/react-query"
+import { axios } from "@/lib/axios"
+import { DocumentDetailCreateRequest } from "../types"
+import { BaseResponse } from "@/types"
+import toast from "react-hot-toast"
+import { AxiosResponse } from "axios"
 
-export const createDocument = (
-  req: DocumentDetailCreateRequest
-): Promise<AxiosResponse<BaseResponse, any>> => {
-  const myPromise = axios.post<BaseResponse>(`/api/document-detail`, req);
+export const createDocument = (req: DocumentDetailCreateRequest): Promise<AxiosResponse<BaseResponse, any>> => {
+  const myPromise = axios.post<BaseResponse>(`/api/document-detail`, req)
   toast.promise(
     myPromise,
     {
@@ -19,22 +17,17 @@ export const createDocument = (
     {
       position: "top-right",
     }
-  );
-  return myPromise;
-};
+  )
+  return myPromise
+}
 
 type UseCreateDocumentOptions = {
-  config?: UseMutationOptions<
-    AxiosResponse<BaseResponse, any>,
-    unknown,
-    DocumentDetailCreateRequest,
-    unknown
-  >;
-};
+  config?: UseMutationOptions<AxiosResponse<BaseResponse, any>, unknown, DocumentDetailCreateRequest, unknown>
+}
 
 export const useCreateDocument = ({ config }: UseCreateDocumentOptions) => {
   return useMutation({
     ...config,
     mutationFn: createDocument,
-  });
-};
+  })
+}

--- a/src/features/documents/api/createDocument.ts
+++ b/src/features/documents/api/createDocument.ts
@@ -1,9 +1,11 @@
 import { useMutation, UseMutationOptions } from "@tanstack/react-query"
-import { axios } from "@/lib/axios"
-import { DocumentDetailCreateRequest } from "../types"
-import { BaseResponse } from "@/types"
-import toast from "react-hot-toast"
 import { AxiosResponse } from "axios"
+import toast from "react-hot-toast"
+
+import { axios } from "@/lib/axios"
+import { BaseResponse } from "@/types"
+
+import { DocumentDetailCreateRequest } from "../types"
 
 export const createDocument = (req: DocumentDetailCreateRequest): Promise<AxiosResponse<BaseResponse, any>> => {
   const myPromise = axios.post<BaseResponse>(`/api/document-detail`, req)

--- a/src/features/documents/api/getDocument.ts
+++ b/src/features/documents/api/getDocument.ts
@@ -1,34 +1,25 @@
-import { useQuery } from "@tanstack/react-query";
-import { axios } from "@/lib/axios";
-import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query";
-import { EventId, DocumentId } from "@/types";
-import { DocumentData } from "@/types/document";
+import { useQuery } from "@tanstack/react-query"
+import { axios } from "@/lib/axios"
+import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
+import { EventId, DocumentId } from "@/types"
+import { DocumentData } from "@/types/document"
 
-export const getDocumentDetail = (req: {
-  eventId: EventId;
-  documentId: DocumentId;
-}): Promise<DocumentData> => {
-  return axios.get(
-    `/api/document-detail?eventId=${req.eventId}&documentId=${req.documentId}`
-  );
-};
+export const getDocumentDetail = (req: { eventId: EventId; documentId: DocumentId }): Promise<DocumentData> => {
+  return axios.get(`/api/document-detail?eventId=${req.eventId}&documentId=${req.documentId}`)
+}
 
-type QueryFnType = typeof getDocumentDetail;
+type QueryFnType = typeof getDocumentDetail
 
 type UseEventListOptions = {
-  eventId: EventId;
-  documentId: DocumentId;
-  config?: QueryConfig<QueryFnType>;
-};
+  eventId: EventId
+  documentId: DocumentId
+  config?: QueryConfig<QueryFnType>
+}
 
-export const useDocumentDetail = ({
-  eventId,
-  documentId,
-  config,
-}: UseEventListOptions) => {
+export const useDocumentDetail = ({ eventId, documentId, config }: UseEventListOptions) => {
   return useQuery<ExtractFnReturnType<QueryFnType>>({
     queryKey: ["event-detail", eventId, documentId],
     queryFn: () => getDocumentDetail({ eventId, documentId }),
     ...config,
-  });
-};
+  })
+}

--- a/src/features/documents/api/getDocument.ts
+++ b/src/features/documents/api/getDocument.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+
 import { axios } from "@/lib/axios"
 import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
 import { EventId, DocumentId } from "@/types"

--- a/src/features/documents/components/DocumentDetail.tsx
+++ b/src/features/documents/components/DocumentDetail.tsx
@@ -34,7 +34,7 @@ export const DocumentDetail: React.FC<Props> = memo(({ eventId, documentId }) =>
         <span>{data.name}</span>
         {data.file && (
           <p>
-            <a target="_blank" href={documentUrl} download={documentName}>
+            <a target="_blank" href={documentUrl} download={documentName} rel="noreferrer">
               ダウンロード
             </a>
           </p>

--- a/src/features/documents/components/DocumentDetail.tsx
+++ b/src/features/documents/components/DocumentDetail.tsx
@@ -1,49 +1,45 @@
-import { PageTitle } from "@/components/PageTitle";
-import { DocumentId, EventId } from "@/types";
-import React, { memo, useMemo } from "react";
-import { useDocumentDetail } from "../api/getDocument";
+import { PageTitle } from "@/components/PageTitle"
+import { DocumentId, EventId } from "@/types"
+import React, { memo, useMemo } from "react"
+import { useDocumentDetail } from "../api/getDocument"
 
 interface Props {
-  eventId: EventId;
-  documentId: DocumentId;
+  eventId: EventId
+  documentId: DocumentId
 }
 
-export const DocumentDetail: React.FC<Props> = memo(
-  ({ eventId, documentId }) => {
-    const { data, isLoading } = useDocumentDetail({ eventId, documentId });
-    console.log(data);
-    // 資料のURL
-    const documentUrl = useMemo(() => {
-      return data?.file
-        ? `https:${(data as any).file.fields.file["en-US"].url}`
-        : data?.url || "";
-    }, [data]);
-    // 資料の名前
-    const documentName = useMemo(() => {
-      const extend = documentUrl.match(/[^.]+$/);
-      return data?.file
-        ? `${(data as any).file.fields.file["en-US"].fileName}`
-        : `${data?.title || "no-title"}.${extend ? extend[0] : ""}`;
-    }, [data, documentUrl]);
-    // ローディング
-    if (isLoading) return <p>Loading...</p>;
-    //   データがない場合
-    if (!data) return <p>no data</p>;
-    return (
-      <>
-        <PageTitle>{data.title}</PageTitle>
-        <div>
-          <span>{data.emoji}</span>
-          <span>{data.name}</span>
-          {data.file && (
-            <p>
-              <a target="_blank" href={documentUrl} download={documentName}>
-                ダウンロード
-              </a>
-            </p>
-          )}
-        </div>
-      </>
-    );
-  }
-);
+export const DocumentDetail: React.FC<Props> = memo(({ eventId, documentId }) => {
+  const { data, isLoading } = useDocumentDetail({ eventId, documentId })
+  console.log(data)
+  // 資料のURL
+  const documentUrl = useMemo(() => {
+    return data?.file ? `https:${(data as any).file.fields.file["en-US"].url}` : data?.url || ""
+  }, [data])
+  // 資料の名前
+  const documentName = useMemo(() => {
+    const extend = documentUrl.match(/[^.]+$/)
+    return data?.file
+      ? `${(data as any).file.fields.file["en-US"].fileName}`
+      : `${data?.title || "no-title"}.${extend ? extend[0] : ""}`
+  }, [data, documentUrl])
+  // ローディング
+  if (isLoading) return <p>Loading...</p>
+  //   データがない場合
+  if (!data) return <p>no data</p>
+  return (
+    <>
+      <PageTitle>{data.title}</PageTitle>
+      <div>
+        <span>{data.emoji}</span>
+        <span>{data.name}</span>
+        {data.file && (
+          <p>
+            <a target="_blank" href={documentUrl} download={documentName}>
+              ダウンロード
+            </a>
+          </p>
+        )}
+      </div>
+    </>
+  )
+})

--- a/src/features/documents/components/DocumentDetail.tsx
+++ b/src/features/documents/components/DocumentDetail.tsx
@@ -1,6 +1,8 @@
+import React, { memo, useMemo } from "react"
+
 import { PageTitle } from "@/components/PageTitle"
 import { DocumentId, EventId } from "@/types"
-import React, { memo, useMemo } from "react"
+
 import { useDocumentDetail } from "../api/getDocument"
 
 interface Props {

--- a/src/features/documents/components/DocumentInput.tsx
+++ b/src/features/documents/components/DocumentInput.tsx
@@ -1,111 +1,93 @@
-import React, { memo } from "react";
-import { Dropzone, FileWithPath, MIME_TYPES } from "@mantine/dropzone";
-import { UseFormReturnType } from "@mantine/form";
-import { Group, Text, createStyles, Box } from "@mantine/core";
-import { FormValues } from "../types";
-import { MdInsertDriveFile, MdCheck, MdOutlineError } from "react-icons/md";
+import React, { memo } from "react"
+import { Dropzone, FileWithPath, MIME_TYPES } from "@mantine/dropzone"
+import { UseFormReturnType } from "@mantine/form"
+import { Group, Text, createStyles, Box } from "@mantine/core"
+import { FormValues } from "../types"
+import { MdInsertDriveFile, MdCheck, MdOutlineError } from "react-icons/md"
 
 const useStyles = createStyles((theme) => ({
   disabled: {
-    backgroundColor:
-      theme.colorScheme === "dark"
-        ? theme.colors.dark[6]
-        : theme.colors.gray[0],
-    borderColor:
-      theme.colorScheme === "dark"
-        ? theme.colors.dark[5]
-        : theme.colors.gray[2],
+    backgroundColor: theme.colorScheme === "dark" ? theme.colors.dark[6] : theme.colors.gray[0],
+    borderColor: theme.colorScheme === "dark" ? theme.colors.dark[5] : theme.colors.gray[2],
     cursor: "not-allowed",
 
     "& *": {
-      color:
-        theme.colorScheme === "dark"
-          ? theme.colors.dark[3]
-          : theme.colors.gray[5],
+      color: theme.colorScheme === "dark" ? theme.colors.dark[3] : theme.colors.gray[5],
     },
   },
-}));
+}))
 
 interface Props {
-  form: UseFormReturnType<FormValues, (values: FormValues) => FormValues>;
-  files: FileWithPath[];
-  setFile: React.Dispatch<React.SetStateAction<string>>;
-  setFiles: React.Dispatch<React.SetStateAction<FileWithPath[]>>;
-  setFileType: React.Dispatch<React.SetStateAction<FileType>>;
-  isLoading: boolean;
+  form: UseFormReturnType<FormValues, (values: FormValues) => FormValues>
+  files: FileWithPath[]
+  setFile: React.Dispatch<React.SetStateAction<string>>
+  setFiles: React.Dispatch<React.SetStateAction<FileWithPath[]>>
+  setFileType: React.Dispatch<React.SetStateAction<FileType>>
+  isLoading: boolean
 }
 
-type FileType = typeof MIME_TYPES[keyof typeof MIME_TYPES] | "";
+type FileType = typeof MIME_TYPES[keyof typeof MIME_TYPES] | ""
 
-const DocumentInput: React.FC<Props> = memo(
-  ({ files, form, setFile, setFileType, setFiles, isLoading }) => {
-    const { classes } = useStyles();
-    /**
-     * ファイル変更処理
-     *
-     * @param {*} files 入力されたファイルデータ
-     */
-    const handleFile = (files: any) => {
-      setFiles(files);
-      const file = files[0];
-      const extension =
-        (Object.keys(MIME_TYPES).find(
-          (key) => MIME_TYPES[key as keyof typeof MIME_TYPES] === file.type
-        ) as FileType) || "";
-      const reader = new FileReader();
-      reader.onloadend = () => {
-        const binaryData = ((reader.result || "") as any)
-          .split(";base64,")
-          .pop();
-        setFile(binaryData);
-        setFileType(extension);
-      };
-      reader.readAsDataURL(file);
-    };
-    return (
-      <>
-        <Dropzone
-          onDrop={(files) => handleFile(files)}
-          onReject={(files) => console.log("rejected files", files)}
-          maxSize={3 * 1024 ** 2}
-          disabled={isLoading}
-          className={isLoading && classes.disabled}
-          // accept={IMAGE_MIME_TYPE}
-          {...form.getInputProps("files")}
-        >
-          <Group
-            position="center"
-            spacing="xl"
-            style={{ minHeight: 160, pointerEvents: "none" }}
-          >
-            <Dropzone.Accept>
-              <MdCheck size={32} color="blue" />
-            </Dropzone.Accept>
-            <Dropzone.Reject>
-              <MdOutlineError size={32} color="red" />
-            </Dropzone.Reject>
-            <Dropzone.Idle>
-              <MdInsertDriveFile size={32} color="gray" />
-            </Dropzone.Idle>
-
-            <div>
-              <Text size="xl" inline>
-                ここに画像をドラッグするか、クリックしてファイルを選択します。
-              </Text>
-              <Text size="sm" color="dimmed" inline mt={7}>
-                ファイルは5MBを超えないようにしてください。
-              </Text>
-            </div>
-          </Group>
-        </Dropzone>
-        {!!files.length && (
-          <Box mt="xs" mb="xl">
-            <Text>アップロードしたファイル：{files[0].name}</Text>
-          </Box>
-        )}
-      </>
-    );
+const DocumentInput: React.FC<Props> = memo(({ files, form, setFile, setFileType, setFiles, isLoading }) => {
+  const { classes } = useStyles()
+  /**
+   * ファイル変更処理
+   *
+   * @param {*} files 入力されたファイルデータ
+   */
+  const handleFile = (files: any) => {
+    setFiles(files)
+    const file = files[0]
+    const extension =
+      (Object.keys(MIME_TYPES).find((key) => MIME_TYPES[key as keyof typeof MIME_TYPES] === file.type) as FileType) ||
+      ""
+    const reader = new FileReader()
+    reader.onloadend = () => {
+      const binaryData = ((reader.result || "") as any).split(";base64,").pop()
+      setFile(binaryData)
+      setFileType(extension)
+    }
+    reader.readAsDataURL(file)
   }
-);
+  return (
+    <>
+      <Dropzone
+        onDrop={(files) => handleFile(files)}
+        onReject={(files) => console.log("rejected files", files)}
+        maxSize={3 * 1024 ** 2}
+        disabled={isLoading}
+        className={isLoading && classes.disabled}
+        // accept={IMAGE_MIME_TYPE}
+        {...form.getInputProps("files")}
+      >
+        <Group position="center" spacing="xl" style={{ minHeight: 160, pointerEvents: "none" }}>
+          <Dropzone.Accept>
+            <MdCheck size={32} color="blue" />
+          </Dropzone.Accept>
+          <Dropzone.Reject>
+            <MdOutlineError size={32} color="red" />
+          </Dropzone.Reject>
+          <Dropzone.Idle>
+            <MdInsertDriveFile size={32} color="gray" />
+          </Dropzone.Idle>
 
-export default DocumentInput;
+          <div>
+            <Text size="xl" inline>
+              ここに画像をドラッグするか、クリックしてファイルを選択します。
+            </Text>
+            <Text size="sm" color="dimmed" inline mt={7}>
+              ファイルは5MBを超えないようにしてください。
+            </Text>
+          </div>
+        </Group>
+      </Dropzone>
+      {!!files.length && (
+        <Box mt="xs" mb="xl">
+          <Text>アップロードしたファイル：{files[0].name}</Text>
+        </Box>
+      )}
+    </>
+  )
+})
+
+export default DocumentInput

--- a/src/features/documents/components/DocumentInput.tsx
+++ b/src/features/documents/components/DocumentInput.tsx
@@ -1,9 +1,10 @@
-import React, { memo } from "react"
+import { Group, Text, createStyles, Box } from "@mantine/core"
 import { Dropzone, FileWithPath, MIME_TYPES } from "@mantine/dropzone"
 import { UseFormReturnType } from "@mantine/form"
-import { Group, Text, createStyles, Box } from "@mantine/core"
-import { FormValues } from "../types"
+import React, { memo } from "react"
 import { MdInsertDriveFile, MdCheck, MdOutlineError } from "react-icons/md"
+
+import { FormValues } from "../types"
 
 const useStyles = createStyles((theme) => ({
   disabled: {

--- a/src/features/documents/components/EmojiInput.tsx
+++ b/src/features/documents/components/EmojiInput.tsx
@@ -1,8 +1,10 @@
-import React, { memo, useState, useEffect } from "react"
-import { TextInput } from "@mantine/core"
-import EmojiPicker from "@/features/documents/components/EmojiPicker"
 import data from "@emoji-mart/data"
+import { TextInput } from "@mantine/core"
 import { UseFormReturnType } from "@mantine/form"
+import React, { memo, useState, useEffect } from "react"
+
+import EmojiPicker from "@/features/documents/components/EmojiPicker"
+
 import { FormValues } from "../types"
 
 interface Props {

--- a/src/features/documents/components/EmojiInput.tsx
+++ b/src/features/documents/components/EmojiInput.tsx
@@ -1,23 +1,23 @@
-import React, { memo, useState, useEffect } from "react";
-import { TextInput } from "@mantine/core";
-import EmojiPicker from "@/features/documents/components/EmojiPicker";
-import data from "@emoji-mart/data";
-import { UseFormReturnType } from "@mantine/form";
-import { FormValues } from "../types";
+import React, { memo, useState, useEffect } from "react"
+import { TextInput } from "@mantine/core"
+import EmojiPicker from "@/features/documents/components/EmojiPicker"
+import data from "@emoji-mart/data"
+import { UseFormReturnType } from "@mantine/form"
+import { FormValues } from "../types"
 
 interface Props {
-    form: UseFormReturnType<FormValues, (values: FormValues) => FormValues>;
+  form: UseFormReturnType<FormValues, (values: FormValues) => FormValues>
 }
 
 const EmojiInput: React.FC<Props> = memo(({ form }) => {
-  const [focused, setFocused] = useState(false);
-  const [emojiFocused, setEmojiFocused] = useState(false);
+  const [focused, setFocused] = useState(false)
+  const [emojiFocused, setEmojiFocused] = useState(false)
   // 一定時間経過後、表示用のフォーカスフラグを立てる
   useEffect(() => {
     if (focused) {
-      setTimeout(() => setEmojiFocused(true), 10);
+      setTimeout(() => setEmojiFocused(true), 10)
     }
-  }, [focused]);
+  }, [focused])
   return (
     <TextInput
       label="アイキャッチ絵文字"
@@ -33,20 +33,20 @@ const EmojiInput: React.FC<Props> = memo(({ form }) => {
             <EmojiPicker
               data={data}
               onEmojiSelect={(data: any) => {
-                form.setFieldValue("emoji", data.native);
-                setFocused(false);
-                setEmojiFocused(false);
+                form.setFieldValue("emoji", data.native)
+                setFocused(false)
+                setEmojiFocused(false)
               }}
               onClickOutside={() => {
-                setFocused(false);
-                setEmojiFocused(false);
+                setFocused(false)
+                setEmojiFocused(false)
               }}
             />
           )}
         </>
       )}
     />
-  );
-});
+  )
+})
 
-export default EmojiInput;
+export default EmojiInput

--- a/src/features/documents/components/EmojiPicker.tsx
+++ b/src/features/documents/components/EmojiPicker.tsx
@@ -1,7 +1,8 @@
+import type EmojiMart from "emoji-mart"
 import React, { Suspense } from "react"
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const Picker = React.lazy(() => import("@emoji-mart/react"))
-import type EmojiMart from "emoji-mart"
 
 export default function EmojiPicker<T extends keyof typeof EmojiMart.Picker.Props>(
   props: Record<T, typeof EmojiMart.Picker.Props[T]["value"]>

--- a/src/features/documents/components/EmojiPicker.tsx
+++ b/src/features/documents/components/EmojiPicker.tsx
@@ -1,14 +1,14 @@
-import React, { Suspense } from "react";
+import React, { Suspense } from "react"
 // @ts-ignore
-const Picker = React.lazy(() => import("@emoji-mart/react"));
-import type EmojiMart from "emoji-mart";
+const Picker = React.lazy(() => import("@emoji-mart/react"))
+import type EmojiMart from "emoji-mart"
 
-export default function EmojiPicker<
-  T extends keyof typeof EmojiMart.Picker.Props
->(props: Record<T, typeof EmojiMart.Picker.Props[T]["value"]>) {
+export default function EmojiPicker<T extends keyof typeof EmojiMart.Picker.Props>(
+  props: Record<T, typeof EmojiMart.Picker.Props[T]["value"]>
+) {
   return (
     <Suspense fallback={<></>}>
       <Picker {...props} />
     </Suspense>
-  );
+  )
 }

--- a/src/features/documents/components/Form.tsx
+++ b/src/features/documents/components/Form.tsx
@@ -1,47 +1,39 @@
-import React, { memo, useState, useMemo } from "react";
-import {
-  TextInput,
-  Input,
-  Button,
-  Group,
-  Select,
-  SegmentedControl,
-  Box,
-} from "@mantine/core";
-import { useForm } from "@mantine/form";
-import { useAuth } from "@/hooks/useAuth";
-import { useRouter } from "next/router";
-import { FileWithPath } from "@mantine/dropzone";
-import EmojiInput from "@/features/documents/components/EmojiInput";
-import DocumentInput from "@/features/documents/components/DocumentInput";
-import { useEventList } from "@/features/events/api/getEventList";
-import { DocumentDetailCreateRequest, FileType, FormValues } from "../types";
-import { useCreateDocument } from "../api/createDocument";
-import { useRouterQuery } from "@/hooks/useRouterQuery";
-import { PageTitle } from "@/components/PageTitle";
+import React, { memo, useState, useMemo } from "react"
+import { TextInput, Input, Button, Group, Select, SegmentedControl, Box } from "@mantine/core"
+import { useForm } from "@mantine/form"
+import { useAuth } from "@/hooks/useAuth"
+import { useRouter } from "next/router"
+import { FileWithPath } from "@mantine/dropzone"
+import EmojiInput from "@/features/documents/components/EmojiInput"
+import DocumentInput from "@/features/documents/components/DocumentInput"
+import { useEventList } from "@/features/events/api/getEventList"
+import { DocumentDetailCreateRequest, FileType, FormValues } from "../types"
+import { useCreateDocument } from "../api/createDocument"
+import { useRouterQuery } from "@/hooks/useRouterQuery"
+import { PageTitle } from "@/components/PageTitle"
 
 export const Form = memo(() => {
-  const { data } = useEventList({});
-  const router = useRouter();
-  const eventId = useRouterQuery("eventId");
-  const [documentType, setDocumentType] = useState("file");
-  const { user } = useAuth();
-  const [file, setFile] = useState("");
-  const [files, setFiles] = useState<FileWithPath[]>([]);
-  const [fileType, setFileType] = useState<FileType>("");
-  const mutation = useCreateDocument({});
+  const { data } = useEventList({})
+  const router = useRouter()
+  const eventId = useRouterQuery("eventId")
+  const [documentType, setDocumentType] = useState("file")
+  const { user } = useAuth()
+  const [file, setFile] = useState("")
+  const [files, setFiles] = useState<FileWithPath[]>([])
+  const [fileType, setFileType] = useState<FileType>("")
+  const mutation = useCreateDocument({})
   const eventCollectionList = useMemo(() => {
-    const list = [];
+    const list = []
     if (data) {
       for (const event in data) {
         list.push({
           value: event,
           label: `${event}開催`,
-        });
+        })
       }
     }
-    return list;
-  }, [data]);
+    return list
+  }, [data])
   const form = useForm({
     initialValues: {
       files,
@@ -51,27 +43,23 @@ export const Form = memo(() => {
       emoji: "",
     },
     validate: {
-      files: (value) =>
-        typeof value !== "object" && documentType === "file"
-          ? "必須項目です"
-          : null,
+      files: (value) => (typeof value !== "object" && documentType === "file" ? "必須項目です" : null),
       url: (value) => {
         if (documentType === "url") {
           if (!value.length) {
-            return "必須項目です";
+            return "必須項目です"
           }
-          let regexp =
-            /https?:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#\u3000-\u30FE\u4E00-\u9FA0\uFF01-\uFFE3]+/g;
+          let regexp = /https?:\/\/[-_.!~*\'()a-zA-Z0-9;\/?:\@&=+\$,%#\u3000-\u30FE\u4E00-\u9FA0\uFF01-\uFFE3]+/g
           if (!regexp.test(value)) {
-            return "URLの形式で入力してください";
+            return "URLの形式で入力してください"
           }
         }
-        return null;
+        return null
       },
       title: (value) => (!!value.trim().length ? null : "必須項目です"),
       emoji: (value) => (!!value.trim().length ? null : "必須項目です"),
     },
-  });
+  })
   const handleSubmit = (values: FormValues) => {
     const req: DocumentDetailCreateRequest = {
       title: values.title,
@@ -85,20 +73,20 @@ export const Form = memo(() => {
       user_id: user?.id || "",
       emoji: values.emoji,
       target_event: eventId,
-    };
+    }
     mutation.mutate(req, {
       onSuccess: () => {
         // 成功時
-        router.push(`/events/${eventId}`);
+        router.push(`/events/${eventId}`)
       },
       onError: (error) => {
         // 失敗時
-        console.error(error);
+        console.error(error)
       },
-    });
-  };
+    })
+  }
   // 勉強会のデータが0件の場合
-  if (!eventCollectionList.length) return <PageTitle>資料の投稿</PageTitle>;
+  if (!eventCollectionList.length) return <PageTitle>資料の投稿</PageTitle>
   return (
     <>
       <PageTitle>資料の投稿</PageTitle>
@@ -114,10 +102,7 @@ export const Form = memo(() => {
           {...form.getInputProps("eventId")}
         />
         {/* LT資料 */}
-        <Input.Wrapper
-          label="資料"
-          description="ファイルか、URLで入力してください"
-        >
+        <Input.Wrapper label="資料" description="ファイルか、URLで入力してください">
           <SegmentedControl
             value={documentType}
             onChange={setDocumentType}
@@ -151,12 +136,7 @@ export const Form = memo(() => {
           />
         </Input.Wrapper>
         {/* 表示タイトル */}
-        <TextInput
-          label="表示タイトル"
-          withAsterisk
-          required
-          {...form.getInputProps("title")}
-        />
+        <TextInput label="表示タイトル" withAsterisk required {...form.getInputProps("title")} />
         {/* アイキャッチ絵文字 */}
         <EmojiInput form={form} />
         <Group position="right" mt="md">
@@ -166,5 +146,5 @@ export const Form = memo(() => {
         </Group>
       </form>
     </>
-  );
-});
+  )
+})

--- a/src/features/documents/components/Form.tsx
+++ b/src/features/documents/components/Form.tsx
@@ -1,16 +1,18 @@
-import React, { memo, useState, useMemo } from "react"
 import { TextInput, Input, Button, Group, Select, SegmentedControl, Box } from "@mantine/core"
-import { useForm } from "@mantine/form"
-import { useAuth } from "@/hooks/useAuth"
-import { useRouter } from "next/router"
 import { FileWithPath } from "@mantine/dropzone"
-import EmojiInput from "@/features/documents/components/EmojiInput"
-import DocumentInput from "@/features/documents/components/DocumentInput"
-import { useEventList } from "@/features/events/api/getEventList"
-import { DocumentDetailCreateRequest, FileType, FormValues } from "../types"
-import { useCreateDocument } from "../api/createDocument"
-import { useRouterQuery } from "@/hooks/useRouterQuery"
+import { useForm } from "@mantine/form"
+import { useRouter } from "next/router"
+import React, { memo, useState, useMemo } from "react"
+
 import { PageTitle } from "@/components/PageTitle"
+import DocumentInput from "@/features/documents/components/DocumentInput"
+import EmojiInput from "@/features/documents/components/EmojiInput"
+import { useEventList } from "@/features/events/api/getEventList"
+import { useAuth } from "@/hooks/useAuth"
+import { useRouterQuery } from "@/hooks/useRouterQuery"
+
+import { useCreateDocument } from "../api/createDocument"
+import { DocumentDetailCreateRequest, FileType, FormValues } from "../types"
 
 export const Form = memo(() => {
   const { data } = useEventList({})

--- a/src/features/documents/functions/getFile.ts
+++ b/src/features/documents/functions/getFile.ts
@@ -1,6 +1,5 @@
 import { CONTENTFUL_BASE_INFO } from "@/constants"
 import client from "@/lib/contentful"
-import { MIME_TYPES } from "@mantine/dropzone"
 import { Asset } from "contentful-management"
 
 export interface GetFileFromContentfulParams {

--- a/src/features/documents/functions/getFile.ts
+++ b/src/features/documents/functions/getFile.ts
@@ -1,10 +1,10 @@
-import { CONTENTFUL_BASE_INFO } from "@/constants";
-import client from "@/lib/contentful";
-import { MIME_TYPES } from "@mantine/dropzone";
-import { Asset } from "contentful-management";
+import { CONTENTFUL_BASE_INFO } from "@/constants"
+import client from "@/lib/contentful"
+import { MIME_TYPES } from "@mantine/dropzone"
+import { Asset } from "contentful-management"
 
 export interface GetFileFromContentfulParams {
-  id: string;
+  id: string
 }
 
 /**
@@ -13,16 +13,14 @@ export interface GetFileFromContentfulParams {
  * @param {GetFileFromContentfulParams} params
  * @returns {Promise<Asset>}
  */
-export const getFileFromContentful = async (
-  params: GetFileFromContentfulParams
-): Promise<Asset> => {
+export const getFileFromContentful = async (params: GetFileFromContentfulParams): Promise<Asset> => {
   // ファイルのアップロード
   const asset = await client
     .getSpace(CONTENTFUL_BASE_INFO.space)
     .then((space) => space.getEnvironment(CONTENTFUL_BASE_INFO.environment))
     .then((environment) => environment.getAsset(params.id))
     .then((asset) => {
-      return asset;
-    });
-  return asset;
-};
+      return asset
+    })
+  return asset
+}

--- a/src/features/documents/functions/getFile.ts
+++ b/src/features/documents/functions/getFile.ts
@@ -1,6 +1,7 @@
+import { Asset } from "contentful-management"
+
 import { CONTENTFUL_BASE_INFO } from "@/constants"
 import client from "@/lib/contentful"
-import { Asset } from "contentful-management"
 
 export interface GetFileFromContentfulParams {
   id: string

--- a/src/features/documents/functions/uploadFile.ts
+++ b/src/features/documents/functions/uploadFile.ts
@@ -1,9 +1,11 @@
-import { CONTENTFUL_BASE_INFO } from "@/constants"
-import client from "@/lib/contentful"
-import { MIME_TYPES } from "@mantine/dropzone"
-import { Asset } from "contentful-management"
 import fs from "fs"
 import path from "path"
+
+import { MIME_TYPES } from "@mantine/dropzone"
+import { Asset } from "contentful-management"
+
+import { CONTENTFUL_BASE_INFO } from "@/constants"
+import client from "@/lib/contentful"
 
 const TMP_FILE_NAME = "tmp"
 

--- a/src/features/documents/functions/uploadFile.ts
+++ b/src/features/documents/functions/uploadFile.ts
@@ -1,16 +1,16 @@
-import { CONTENTFUL_BASE_INFO } from "@/constants";
-import client from "@/lib/contentful";
-import { MIME_TYPES } from "@mantine/dropzone";
-import { Asset } from "contentful-management";
-import fs from "fs";
-import path from "path";
+import { CONTENTFUL_BASE_INFO } from "@/constants"
+import client from "@/lib/contentful"
+import { MIME_TYPES } from "@mantine/dropzone"
+import { Asset } from "contentful-management"
+import fs from "fs"
+import path from "path"
 
-const TMP_FILE_NAME = "tmp";
+const TMP_FILE_NAME = "tmp"
 
 export interface UploadFileToContentfulParams {
-  data: string;
-  extension: keyof typeof MIME_TYPES;
-  title: string;
+  data: string
+  extension: keyof typeof MIME_TYPES
+  title: string
 }
 
 /**
@@ -19,18 +19,16 @@ export interface UploadFileToContentfulParams {
  * @param {UploadFileToContentfulParams} params
  * @returns {Promise<Asset>}
  */
-export const uploadFileToContentful = async (
-  params: UploadFileToContentfulParams
-): Promise<Asset> => {
-  const { data, extension, title } = params;
-  const mimeType = MIME_TYPES[params.extension];
+export const uploadFileToContentful = async (params: UploadFileToContentfulParams): Promise<Asset> => {
+  const { data, extension, title } = params
+  const mimeType = MIME_TYPES[params.extension]
   // 一時ファイルの作成
   fs.writeFileSync(`./public/${TMP_FILE_NAME}.${extension}`, data, {
     encoding: "base64",
-  });
+  })
   // 一時ファイルの読み込み
-  const filePath = path.resolve("./public", `${TMP_FILE_NAME}.${extension}`);
-  const tmpFile = fs.readFileSync(filePath);
+  const filePath = path.resolve("./public", `${TMP_FILE_NAME}.${extension}`)
+  const tmpFile = fs.readFileSync(filePath)
   // ファイルのアップロード
   const upload = await client
     .getSpace(CONTENTFUL_BASE_INFO.space)
@@ -41,8 +39,8 @@ export const uploadFileToContentful = async (
       })
     )
     .then((upload) => {
-      return upload;
-    });
+      return upload
+    })
   // アセットの作成と公開
   const asset = await client
     .getSpace(CONTENTFUL_BASE_INFO.space)
@@ -70,18 +68,18 @@ export const uploadFileToContentful = async (
           },
         })
         .then((asset) => {
-          return asset.processForAllLocales({ processingCheckWait: 2000 });
+          return asset.processForAllLocales({ processingCheckWait: 2000 })
         })
         .then((asset) => {
-          return asset.publish();
+          return asset.publish()
         })
         .then((asset) => {
-          return asset;
-        });
-    });
+          return asset
+        })
+    })
   // 一時ファイルの削除
   fs.unlink(`./public/${TMP_FILE_NAME}.${extension}`, (err) => {
-    if (err) throw err;
-  });
-  return asset;
-};
+    if (err) throw err
+  })
+  return asset
+}

--- a/src/features/documents/index.ts
+++ b/src/features/documents/index.ts
@@ -1,3 +1,3 @@
-export * from "./types";
-export * from "./components/Form";
-export * from "./components/DocumentDetail";
+export * from "./types"
+export * from "./components/Form"
+export * from "./components/DocumentDetail"

--- a/src/features/documents/types/index.ts
+++ b/src/features/documents/types/index.ts
@@ -1,5 +1,6 @@
-import { DocumentData } from "@/types/document"
 import { FileWithPath, MIME_TYPES } from "@mantine/dropzone"
+
+import { DocumentData } from "@/types/document"
 
 export type FormValues = {
   files: FileWithPath[]

--- a/src/features/documents/types/index.ts
+++ b/src/features/documents/types/index.ts
@@ -1,41 +1,40 @@
-import { DocumentData } from "@/types/document";
-import { FileWithPath, MIME_TYPES } from "@mantine/dropzone";
+import { DocumentData } from "@/types/document"
+import { FileWithPath, MIME_TYPES } from "@mantine/dropzone"
 
 export type FormValues = {
-    files: FileWithPath[];
-    url: string;
-    eventId: string;
-    title: string;
-    emoji: string;
-  };
+  files: FileWithPath[]
+  url: string
+  eventId: string
+  title: string
+  emoji: string
+}
 
-export type FileType = typeof MIME_TYPES[keyof typeof MIME_TYPES] | "";
-
+export type FileType = typeof MIME_TYPES[keyof typeof MIME_TYPES] | ""
 
 export type DocumentDetailResponse = DocumentData
 
 export interface DocumentDetailCreateRequest {
-  name: string;
-  user_id: string;
-  url?: string | null;
-  title: string;
-  emoji: string;
-  target_event: string;
+  name: string
+  user_id: string
+  url?: string | null
+  title: string
+  emoji: string
+  target_event: string
   file?: {
-    data: string;
-    type: string;
-  } | null;
+    data: string
+    type: string
+  } | null
 }
 export interface DocumentDetailUpdateRequest {
-  name: string;
-  user_id: string;
-  url: string | null;
-  title: string;
-  emoji: string;
-  target_event: string;
+  name: string
+  user_id: string
+  url: string | null
+  title: string
+  emoji: string
+  target_event: string
   file: {
-    data: string;
-    type: string;
-  } | null;
-  id: string;
+    data: string
+    type: string
+  } | null
+  id: string
 }

--- a/src/features/events/api/getEventDetail.ts
+++ b/src/features/events/api/getEventDetail.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+
 import { axios } from "@/lib/axios"
 import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
 import { UserId } from "@/types"

--- a/src/features/events/api/getEventDetail.ts
+++ b/src/features/events/api/getEventDetail.ts
@@ -1,26 +1,24 @@
-import { useQuery } from "@tanstack/react-query";
-import { axios } from "@/lib/axios";
-import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query";
-import { UserId } from "@/types";
-import { DocumentData } from "@/types/document";
+import { useQuery } from "@tanstack/react-query"
+import { axios } from "@/lib/axios"
+import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
+import { UserId } from "@/types"
+import { DocumentData } from "@/types/document"
 
-export const getEventDetail = (req: {
-    eventId: string;
-  }): Promise<Record<UserId, DocumentData>> => {
-  return axios.get(`/api/event-detail?eventId=${req.eventId}`);
-};
+export const getEventDetail = (req: { eventId: string }): Promise<Record<UserId, DocumentData>> => {
+  return axios.get(`/api/event-detail?eventId=${req.eventId}`)
+}
 
-type QueryFnType = typeof getEventDetail;
+type QueryFnType = typeof getEventDetail
 
 type UseEventListOptions = {
-    eventId: string
-  config?: QueryConfig<QueryFnType>;
-};
+  eventId: string
+  config?: QueryConfig<QueryFnType>
+}
 
 export const useEventDetail = ({ eventId, config }: UseEventListOptions) => {
   return useQuery<ExtractFnReturnType<QueryFnType>>({
     queryKey: ["event-detail", eventId],
-    queryFn: () => getEventDetail({eventId}),
+    queryFn: () => getEventDetail({ eventId }),
     ...config,
-  });
-};
+  })
+}

--- a/src/features/events/api/getEventList.ts
+++ b/src/features/events/api/getEventList.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+
 import { axios } from "@/lib/axios"
 import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
 import { UserId } from "@/types"

--- a/src/features/events/api/getEventList.ts
+++ b/src/features/events/api/getEventList.ts
@@ -1,23 +1,23 @@
-import { useQuery } from "@tanstack/react-query";
-import { axios } from "@/lib/axios";
-import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query";
-import { UserId } from "@/types";
-import { DocumentData } from "@/types/document";
+import { useQuery } from "@tanstack/react-query"
+import { axios } from "@/lib/axios"
+import { ExtractFnReturnType, QueryConfig } from "@/lib/react-query"
+import { UserId } from "@/types"
+import { DocumentData } from "@/types/document"
 
 export const getEventList = (): Promise<Record<string, Record<UserId, DocumentData>>> => {
-  return axios.get(`/api/event-collection`);
-};
+  return axios.get(`/api/event-collection`)
+}
 
-type QueryFnType = typeof getEventList;
+type QueryFnType = typeof getEventList
 
 type UseEventListOptions = {
-  config?: QueryConfig<QueryFnType>;
-};
+  config?: QueryConfig<QueryFnType>
+}
 
 export const useEventList = ({ config }: UseEventListOptions) => {
   return useQuery<ExtractFnReturnType<QueryFnType>>({
     queryKey: ["event-collection"],
     queryFn: () => getEventList(),
     ...config,
-  });
-};
+  })
+}

--- a/src/features/events/components/DocumentList.tsx
+++ b/src/features/events/components/DocumentList.tsx
@@ -1,42 +1,50 @@
-import React, { memo, useMemo } from 'react'
-import Link from "next/link";
-import { DocumentCard } from "@/components/DocumentCard";
-import { useEventListData } from '../hooks/useEventListData';
-import { Group, Paper } from '@mantine/core';
-import { EventId, UserId } from '@/types';
-import { DocumentData } from '@/types/document';
+import React, { memo, useMemo } from "react"
+import Link from "next/link"
+import { DocumentCard } from "@/components/DocumentCard"
+import { useEventListData } from "../hooks/useEventListData"
+import { Group, Paper } from "@mantine/core"
+import { EventId, UserId } from "@/types"
+import { DocumentData } from "@/types/document"
 
 interface Props {
-    eventId: string
-    data?: Record<EventId, Record<UserId, DocumentData>> 
+  eventId: string
+  data?: Record<EventId, Record<UserId, DocumentData>>
 }
 
-const DocumentList: React.FC<Props> = memo(({eventId, data}) => {
-    const {getUserList, getDocument} = useEventListData(data)
-    const userList = useMemo(() => getUserList(eventId), [getUserList])
-    return (
-        <Paper bg="gray.0" p="md" radius="md" sx={{ minHeight: "140px", display: "flex", alignItems: "center", justifyContent: userList.length ? "flex-start" : "center" }}>
-        {!userList.length ? (
-          <span>アップロードされた資料はありません</span>
-        ) : (
-          <Group>
-            {userList.map((userId) => {
-              const document = getDocument(eventId, userId);
-              if (!document) return <></>;
-              return (
-                <React.Fragment key={userId}>
-                  <Link
-                    href={`/events/${eventId}/documents/${userId}`}
-                  >
-                    <DocumentCard emoji={document.emoji} title={document.title} name={document.name} />
-                  </Link>
-                </React.Fragment>
-              );
-            })}
-          </Group>
-        )}
-      </Paper>
-    )
-  })
+const DocumentList: React.FC<Props> = memo(({ eventId, data }) => {
+  const { getUserList, getDocument } = useEventListData(data)
+  const userList = useMemo(() => getUserList(eventId), [getUserList])
+  return (
+    <Paper
+      bg="gray.0"
+      p="md"
+      radius="md"
+      sx={{
+        minHeight: "140px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: userList.length ? "flex-start" : "center",
+      }}
+    >
+      {!userList.length ? (
+        <span>アップロードされた資料はありません</span>
+      ) : (
+        <Group>
+          {userList.map((userId) => {
+            const document = getDocument(eventId, userId)
+            if (!document) return <></>
+            return (
+              <React.Fragment key={userId}>
+                <Link href={`/events/${eventId}/documents/${userId}`}>
+                  <DocumentCard emoji={document.emoji} title={document.title} name={document.name} />
+                </Link>
+              </React.Fragment>
+            )
+          })}
+        </Group>
+      )}
+    </Paper>
+  )
+})
 
 export default DocumentList

--- a/src/features/events/components/DocumentList.tsx
+++ b/src/features/events/components/DocumentList.tsx
@@ -1,10 +1,12 @@
-import React, { memo, useMemo } from "react"
-import Link from "next/link"
-import { DocumentCard } from "@/components/DocumentCard"
-import { useEventListData } from "../hooks/useEventListData"
 import { Group, Paper } from "@mantine/core"
+import Link from "next/link"
+import React, { memo, useMemo } from "react"
+
+import { DocumentCard } from "@/components/DocumentCard"
 import { EventId, UserId } from "@/types"
 import { DocumentData } from "@/types/document"
+
+import { useEventListData } from "../hooks/useEventListData"
 
 interface Props {
   eventId: string

--- a/src/features/events/components/EventDetail.tsx
+++ b/src/features/events/components/EventDetail.tsx
@@ -1,23 +1,23 @@
-import { Group } from "@mantine/core";
-import Link from "next/link";
-import React, { memo, useMemo } from "react";
-import { DocumentCard } from "@/components/DocumentCard";
-import { useEventDetail } from "../api/getEventDetail";
-import { useEventDetailData } from "../hooks/useEventDetailData";
-import { UploadDocumentFloatingButton } from "./UploadDocumentFloatingButton";
-import { EventId } from "@/types";
-import { PageTitle } from "@/components/PageTitle";
+import { Group } from "@mantine/core"
+import Link from "next/link"
+import React, { memo, useMemo } from "react"
+import { DocumentCard } from "@/components/DocumentCard"
+import { useEventDetail } from "../api/getEventDetail"
+import { useEventDetailData } from "../hooks/useEventDetailData"
+import { UploadDocumentFloatingButton } from "./UploadDocumentFloatingButton"
+import { EventId } from "@/types"
+import { PageTitle } from "@/components/PageTitle"
 
 interface Props {
-  eventId: EventId;
+  eventId: EventId
 }
 
 export const EventDetail: React.FC<Props> = memo(({ eventId }) => {
-  const { data, isLoading } = useEventDetail({ eventId });
-  const { userList, getDocument } = useEventDetailData(data);
+  const { data, isLoading } = useEventDetail({ eventId })
+  const { userList, getDocument } = useEventDetailData(data)
   const pageTitle = useMemo(() => {
-    return `${eventId}開催`;
-  }, [eventId]);
+    return `${eventId}開催`
+  }, [eventId])
   // ローディング
   if (isLoading)
     return (
@@ -25,7 +25,7 @@ export const EventDetail: React.FC<Props> = memo(({ eventId }) => {
         <PageTitle>{pageTitle}</PageTitle>
         <p>Loading...</p>
       </>
-    );
+    )
   // データ0件
   if (!userList.length)
     return (
@@ -34,30 +34,23 @@ export const EventDetail: React.FC<Props> = memo(({ eventId }) => {
         <p>no data</p>
         <UploadDocumentFloatingButton url={`/events/${eventId}/upload`} />
       </>
-    );
+    )
   return (
     <>
       <PageTitle>{pageTitle}</PageTitle>
       <Group>
         {userList.map((userId) => {
-          const document = getDocument(userId);
+          const document = getDocument(userId)
           return (
             <React.Fragment key={userId}>
-              <Link
-                href={`/events/${eventId}/documents/${userId}`}
-                style={{ textDecoration: "none" }}
-              >
-                <DocumentCard
-                  emoji={document?.emoji || ""}
-                  title={document?.title || ""}
-                  name={document?.name || ""}
-                />
+              <Link href={`/events/${eventId}/documents/${userId}`} style={{ textDecoration: "none" }}>
+                <DocumentCard emoji={document?.emoji || ""} title={document?.title || ""} name={document?.name || ""} />
               </Link>
             </React.Fragment>
-          );
+          )
         })}
       </Group>
       <UploadDocumentFloatingButton url={`/events/${eventId}/upload`} />
     </>
-  );
-});
+  )
+})

--- a/src/features/events/components/EventDetail.tsx
+++ b/src/features/events/components/EventDetail.tsx
@@ -1,12 +1,14 @@
 import { Group } from "@mantine/core"
 import Link from "next/link"
 import React, { memo, useMemo } from "react"
+
 import { DocumentCard } from "@/components/DocumentCard"
+import { PageTitle } from "@/components/PageTitle"
+import { EventId } from "@/types"
+
 import { useEventDetail } from "../api/getEventDetail"
 import { useEventDetailData } from "../hooks/useEventDetailData"
 import { UploadDocumentFloatingButton } from "./UploadDocumentFloatingButton"
-import { EventId } from "@/types"
-import { PageTitle } from "@/components/PageTitle"
 
 interface Props {
   eventId: EventId

--- a/src/features/events/components/EventList.tsx
+++ b/src/features/events/components/EventList.tsx
@@ -1,10 +1,12 @@
-import { useEventList } from "../api/getEventList"
-import React from "react"
-import Link from "next/link"
-import DocumentList from "./DocumentList"
-import { useEventListData } from "../hooks/useEventListData"
 import { Flex, Paper, Stack } from "@mantine/core"
+import Link from "next/link"
+import React from "react"
+
 import { PageTitle } from "@/components/PageTitle"
+
+import { useEventList } from "../api/getEventList"
+import { useEventListData } from "../hooks/useEventListData"
+import DocumentList from "./DocumentList"
 
 export const EventList = () => {
   const { data, isLoading } = useEventList({})

--- a/src/features/events/components/EventList.tsx
+++ b/src/features/events/components/EventList.tsx
@@ -1,14 +1,14 @@
-import { useEventList } from "../api/getEventList";
-import React from "react";
-import Link from "next/link";
-import DocumentList from "./DocumentList";
-import { useEventListData } from "../hooks/useEventListData";
-import { Flex, Paper, Stack } from "@mantine/core";
-import { PageTitle } from "@/components/PageTitle";
+import { useEventList } from "../api/getEventList"
+import React from "react"
+import Link from "next/link"
+import DocumentList from "./DocumentList"
+import { useEventListData } from "../hooks/useEventListData"
+import { Flex, Paper, Stack } from "@mantine/core"
+import { PageTitle } from "@/components/PageTitle"
 
 export const EventList = () => {
-  const { data, isLoading } = useEventList({});
-  const { eventCollectionKeys } = useEventListData(data);
+  const { data, isLoading } = useEventList({})
+  const { eventCollectionKeys } = useEventListData(data)
   // ローディング
   if (isLoading) {
     return (
@@ -16,7 +16,7 @@ export const EventList = () => {
         <PageTitle>勉強会一覧</PageTitle>
         <span>loading...</span>
       </>
-    );
+    )
   }
   // データ0件
   if (data && !Object.keys(data).length) {
@@ -25,7 +25,7 @@ export const EventList = () => {
         <PageTitle>勉強会一覧</PageTitle>
         <span>no data</span>
       </>
-    );
+    )
   }
   return (
     <>
@@ -46,5 +46,5 @@ export const EventList = () => {
         ))}
       </Stack>
     </>
-  );
-};
+  )
+}

--- a/src/features/events/components/UploadDocumentFloatingButton.tsx
+++ b/src/features/events/components/UploadDocumentFloatingButton.tsx
@@ -1,9 +1,9 @@
-import React, { memo } from "react";
-import { Button } from "@mantine/core";
-import Link from "next/link";
+import React, { memo } from "react"
+import { Button } from "@mantine/core"
+import Link from "next/link"
 
 interface Props {
-  url: string;
+  url: string
 }
 
 export const UploadDocumentFloatingButton: React.FC<Props> = memo(({ url }) => {
@@ -22,5 +22,5 @@ export const UploadDocumentFloatingButton: React.FC<Props> = memo(({ url }) => {
     >
       資料の追加
     </Button>
-  );
-});
+  )
+})

--- a/src/features/events/components/UploadDocumentFloatingButton.tsx
+++ b/src/features/events/components/UploadDocumentFloatingButton.tsx
@@ -1,6 +1,6 @@
-import React, { memo } from "react"
 import { Button } from "@mantine/core"
 import Link from "next/link"
+import React, { memo } from "react"
 
 interface Props {
   url: string

--- a/src/features/events/hooks/useEventDetailData.ts
+++ b/src/features/events/hooks/useEventDetailData.ts
@@ -1,6 +1,7 @@
+import { useCallback, useMemo } from "react"
+
 import { UserId } from "@/types"
 import { DocumentData } from "@/types/document"
-import { useCallback, useMemo } from "react"
 
 export const useEventDetailData = (data: Record<UserId, DocumentData> | undefined) => {
   /**

--- a/src/features/events/hooks/useEventDetailData.ts
+++ b/src/features/events/hooks/useEventDetailData.ts
@@ -1,34 +1,34 @@
-import { UserId } from '@/types';
-import { DocumentData } from '@/types/document';
-import {useCallback, useMemo} from 'react';
+import { UserId } from "@/types"
+import { DocumentData } from "@/types/document"
+import { useCallback, useMemo } from "react"
 
 export const useEventDetailData = (data: Record<UserId, DocumentData> | undefined) => {
-  /** 
+  /**
    * ユーザー情報一覧
-   * 
+   *
    * @type {string[]}
    */
-   const userList = useMemo(() => {
+  const userList = useMemo(() => {
     if (data) {
-      return Object.keys(data);
+      return Object.keys(data)
     }
-    return [];
-  }, [data]);
+    return []
+  }, [data])
   /**
    * 資料データの取得
-   * 
- * @param {string}  userId ユーザーID
- * @return {DocumentData | null} ドキュメント情報
- */
+   *
+   * @param {string}  userId ユーザーID
+   * @return {DocumentData | null} ドキュメント情報
+   */
   const getDocument = useCallback(
     (userId: string) => {
       if (data) {
-        const eventData = data[userId];
-        return eventData || null;
+        const eventData = data[userId]
+        return eventData || null
       }
-      return null;
+      return null
     },
     [data]
-  );
-  return { userList, getDocument };
-};
+  )
+  return { userList, getDocument }
+}

--- a/src/features/events/hooks/useEventListData.ts
+++ b/src/features/events/hooks/useEventListData.ts
@@ -1,6 +1,7 @@
+import { useCallback, useMemo } from "react"
+
 import { EventId, UserId } from "@/types"
 import { DocumentData } from "@/types/document"
-import { useCallback, useMemo } from "react"
 
 export const useEventListData = (data: Record<EventId, Record<UserId, DocumentData>> | undefined) => {
   /**

--- a/src/features/events/hooks/useEventListData.ts
+++ b/src/features/events/hooks/useEventListData.ts
@@ -1,54 +1,53 @@
-import { EventId, UserId } from '@/types';
-import { DocumentData } from '@/types/document';
-import {useCallback, useMemo} from 'react';
+import { EventId, UserId } from "@/types"
+import { DocumentData } from "@/types/document"
+import { useCallback, useMemo } from "react"
 
 export const useEventListData = (data: Record<EventId, Record<UserId, DocumentData>> | undefined) => {
-  /** 
+  /**
    * イベントごとのキー情報
-   * 
+   *
    * @type {string[]}
    */
-    const eventCollectionKeys = useMemo(() => {
+  const eventCollectionKeys = useMemo(() => {
     if (data) {
-      return Object.keys(data);
+      return Object.keys(data)
     }
-    return [];
-  }, [data]);
-    
+    return []
+  }, [data])
+
   /**
    * イベントに資料を登録したユーザー一覧の取得
-   * 
- * @param {string}  eventId イベントID
- * @return {string[]} ユーザー一覧
- */
-   const getUserList = useCallback(
+   *
+   * @param {string}  eventId イベントID
+   * @return {string[]} ユーザー一覧
+   */
+  const getUserList = useCallback(
     (eventId: string) => {
       if (data) {
-        const eventData = data[eventId];
-        return Object.keys(eventData);
+        const eventData = data[eventId]
+        return Object.keys(eventData)
       }
-      return [];
+      return []
     },
     [data]
-  );
-  
-  
+  )
+
   /**
    * 資料データの取得
-   * 
- * @param {string}  eventId イベントID
- * @param {string}  userId ユーザーID
- * @return {DocumentData | null} ドキュメント情報
- */
+   *
+   * @param {string}  eventId イベントID
+   * @param {string}  userId ユーザーID
+   * @return {DocumentData | null} ドキュメント情報
+   */
   const getDocument = useCallback(
     (eventId: string, userId: string) => {
       if (data) {
-        const eventData = data[eventId][userId];
-        return eventData || null;
+        const eventData = data[eventId][userId]
+        return eventData || null
       }
-      return null;
+      return null
     },
     [data]
-  );
-  return { eventCollectionKeys, getUserList, getDocument };
-};
+  )
+  return { eventCollectionKeys, getUserList, getDocument }
+}

--- a/src/features/misc/pages/DocumentDetail.tsx
+++ b/src/features/misc/pages/DocumentDetail.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react"
+
 import { DocumentDetail } from "@/features/documents"
 import { useRouterQuery } from "@/hooks/useRouterQuery"
 

--- a/src/features/misc/pages/DocumentDetail.tsx
+++ b/src/features/misc/pages/DocumentDetail.tsx
@@ -1,13 +1,13 @@
-import React, { memo } from "react";
-import { DocumentDetail } from "@/features/documents";
-import { useRouterQuery } from "@/hooks/useRouterQuery";
+import React, { memo } from "react"
+import { DocumentDetail } from "@/features/documents"
+import { useRouterQuery } from "@/hooks/useRouterQuery"
 
 export const DocumentDetailPage: React.FC = memo(() => {
-  const eventId = useRouterQuery("eventId");
-  const documentId = useRouterQuery("documentId");
+  const eventId = useRouterQuery("eventId")
+  const documentId = useRouterQuery("documentId")
   return (
     <>
       <DocumentDetail eventId={eventId} documentId={documentId} />
     </>
-  );
-});
+  )
+})

--- a/src/features/misc/pages/DocumentUpload.tsx
+++ b/src/features/misc/pages/DocumentUpload.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react"
+
 import { Form } from "@/features/documents"
 
 export const DocumentUploadPage: React.FC = memo(() => {

--- a/src/features/misc/pages/DocumentUpload.tsx
+++ b/src/features/misc/pages/DocumentUpload.tsx
@@ -1,10 +1,10 @@
-import React, { memo } from "react";
-import { Form } from "@/features/documents";
+import React, { memo } from "react"
+import { Form } from "@/features/documents"
 
 export const DocumentUploadPage: React.FC = memo(() => {
   return (
     <>
       <Form />
     </>
-  );
-});
+  )
+})

--- a/src/features/misc/pages/EventDetail.tsx
+++ b/src/features/misc/pages/EventDetail.tsx
@@ -1,5 +1,6 @@
-import { EventDetail } from "@/features/events"
 import React, { memo } from "react"
+
+import { EventDetail } from "@/features/events"
 import { useRouterQuery } from "@/hooks/useRouterQuery"
 
 export const EventDetailPage: React.FC = memo(() => {

--- a/src/features/misc/pages/EventDetail.tsx
+++ b/src/features/misc/pages/EventDetail.tsx
@@ -1,8 +1,8 @@
-import { EventDetail } from "@/features/events";
-import React, { memo } from "react";
-import { useRouterQuery } from "@/hooks/useRouterQuery";
+import { EventDetail } from "@/features/events"
+import React, { memo } from "react"
+import { useRouterQuery } from "@/hooks/useRouterQuery"
 
 export const EventDetailPage: React.FC = memo(() => {
-  const eventId = useRouterQuery("eventId");
-  return <EventDetail eventId={eventId} />;
-});
+  const eventId = useRouterQuery("eventId")
+  return <EventDetail eventId={eventId} />
+})

--- a/src/features/misc/pages/EventList.tsx
+++ b/src/features/misc/pages/EventList.tsx
@@ -1,6 +1,6 @@
-import React, { memo } from "react";
-import { EventList } from "@/features/events";
+import React, { memo } from "react"
+import { EventList } from "@/features/events"
 
 export const EventListPage: React.FC = memo(() => {
-  return <EventList />;
-});
+  return <EventList />
+})

--- a/src/features/misc/pages/EventList.tsx
+++ b/src/features/misc/pages/EventList.tsx
@@ -1,4 +1,5 @@
 import React, { memo } from "react"
+
 import { EventList } from "@/features/events"
 
 export const EventListPage: React.FC = memo(() => {

--- a/src/features/misc/pages/Index.tsx
+++ b/src/features/misc/pages/Index.tsx
@@ -1,9 +1,10 @@
-import React, { memo } from "react"
-import Image from "next/image"
 import { Text, Paper, Box, Button } from "@mantine/core"
+import Image from "next/image"
+import Link from "next/link"
+import React, { memo } from "react"
+
 import { Spacer } from "@/components/system/Spacer"
 import { useAuth } from "@/hooks/useAuth"
-import Link from "next/link"
 
 export const IndexPage = memo(() => {
   const { user } = useAuth()

--- a/src/features/misc/pages/Index.tsx
+++ b/src/features/misc/pages/Index.tsx
@@ -1,12 +1,12 @@
-import React, { memo } from "react";
-import Image from "next/image";
-import { Text, Paper, Box, Button } from "@mantine/core";
-import { Spacer } from "@/components/system/Spacer";
-import { useAuth } from "@/hooks/useAuth";
-import Link from "next/link";
+import React, { memo } from "react"
+import Image from "next/image"
+import { Text, Paper, Box, Button } from "@mantine/core"
+import { Spacer } from "@/components/system/Spacer"
+import { useAuth } from "@/hooks/useAuth"
+import Link from "next/link"
 
 export const IndexPage = memo(() => {
-  const { user } = useAuth();
+  const { user } = useAuth()
   return (
     <>
       <Text component="h1" sx={{ visibility: "hidden" }}>
@@ -15,12 +15,7 @@ export const IndexPage = memo(() => {
       <Box sx={{ display: "flex" }}>
         <Spacer />
         <Paper shadow="md" p="md" radius={16} sx={{ display: "inline-flex" }}>
-          <Image
-            src="/images/logo.svg"
-            width={120}
-            height={120}
-            alt="つながるLT"
-          />
+          <Image src="/images/logo.svg" width={120} height={120} alt="つながるLT" />
         </Paper>
         <Spacer />
       </Box>
@@ -37,11 +32,7 @@ export const IndexPage = memo(() => {
           }}
         >
           <Link href="/events" passHref>
-            <Button
-              component="a"
-              variant="gradient"
-              gradient={{ from: "teal", to: "lime", deg: 105 }}
-            >
+            <Button component="a" variant="gradient" gradient={{ from: "teal", to: "lime", deg: 105 }}>
               勉強会一覧を見る
             </Button>
           </Link>
@@ -52,5 +43,5 @@ export const IndexPage = memo(() => {
         </Link>
       )}
     </>
-  );
-});
+  )
+})

--- a/src/features/misc/pages/Login.tsx
+++ b/src/features/misc/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { memo, useEffect, useState } from "react"
-import { Text, Paper, Box, Button } from "@mantine/core"
+import { Text, Button } from "@mantine/core"
 import { useAuth } from "@/hooks/useAuth"
 import { LogoSlack } from "react-ionicons"
 import SystemHelper from "@/functions/system"

--- a/src/features/misc/pages/Login.tsx
+++ b/src/features/misc/pages/Login.tsx
@@ -1,8 +1,9 @@
-import React, { memo, useEffect, useState } from "react"
 import { Text, Button } from "@mantine/core"
-import { useAuth } from "@/hooks/useAuth"
+import React, { memo, useEffect, useState } from "react"
 import { LogoSlack } from "react-ionicons"
+
 import SystemHelper from "@/functions/system"
+import { useAuth } from "@/hooks/useAuth"
 
 const BASE_URL = `https://slack.com/oauth/authorize?scope=team:read,users:read&client_id=${process.env.NEXT_PUBLIC_SLACK_CLIENT_ID}&state=`
 

--- a/src/features/misc/pages/Login.tsx
+++ b/src/features/misc/pages/Login.tsx
@@ -1,25 +1,22 @@
-import React, { memo, useEffect, useState } from "react";
-import { Text, Paper, Box, Button } from "@mantine/core";
-import { useAuth } from "@/hooks/useAuth";
-import { LogoSlack } from "react-ionicons";
-import SystemHelper from "@/functions/system";
+import React, { memo, useEffect, useState } from "react"
+import { Text, Paper, Box, Button } from "@mantine/core"
+import { useAuth } from "@/hooks/useAuth"
+import { LogoSlack } from "react-ionicons"
+import SystemHelper from "@/functions/system"
 
-const BASE_URL = `https://slack.com/oauth/authorize?scope=team:read,users:read&client_id=${process.env.NEXT_PUBLIC_SLACK_CLIENT_ID}&state=`;
+const BASE_URL = `https://slack.com/oauth/authorize?scope=team:read,users:read&client_id=${process.env.NEXT_PUBLIC_SLACK_CLIENT_ID}&state=`
 
 export const LoginPage = memo(() => {
-  const { isLoading } = useAuth();
-  const [slackAuthUrl, setSlackAuthUrl] = useState(BASE_URL);
+  const { isLoading } = useAuth()
+  const [slackAuthUrl, setSlackAuthUrl] = useState(BASE_URL)
   // slack認証用のURL
   useEffect(() => {
-    if (SystemHelper.isBrowser)
-      setSlackAuthUrl(`${BASE_URL}${window.location.href}`);
-  }, []);
+    if (SystemHelper.isBrowser) setSlackAuthUrl(`${BASE_URL}${window.location.href}`)
+  }, [])
   return (
     <>
       <Text component="h1">ログイン</Text>
-      <Text>
-        slackのコミュニティに所属しているメンバーであればログイン可能です
-      </Text>
+      <Text>slackのコミュニティに所属しているメンバーであればログイン可能です</Text>
       <Button
         component="a"
         href={slackAuthUrl}
@@ -33,5 +30,5 @@ export const LoginPage = memo(() => {
         Slackでログイン
       </Button>
     </>
-  );
-});
+  )
+})

--- a/src/functions/system.ts
+++ b/src/functions/system.ts
@@ -1,5 +1,5 @@
 class SystemHelper {
-  public static isBrowser = typeof window !== "undefined";
+  public static isBrowser = typeof window !== "undefined"
 }
 
-export default SystemHelper;
+export default SystemHelper

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useEffect } from "react"
 import { getAuth, signInWithCustomToken } from "firebase/auth"
-import { firebaseApp } from "@/lib/firebase"
 import { signIn, signOut, useSession } from "next-auth/react"
 import { useRouter } from "next/router"
+import { useCallback, useMemo, useEffect } from "react"
+
+import { firebaseApp } from "@/lib/firebase"
 
 export type UseAuth = () => {
   handleLogout: () => void

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,72 +1,65 @@
-import { useCallback, useMemo, useEffect } from "react";
-import { getAuth, signInWithCustomToken } from "firebase/auth";
-import { firebaseApp } from "@/lib/firebase";
-import { signIn, signOut, useSession } from "next-auth/react";
-import { useRouter } from "next/router";
+import { useCallback, useMemo, useEffect } from "react"
+import { getAuth, signInWithCustomToken } from "firebase/auth"
+import { firebaseApp } from "@/lib/firebase"
+import { signIn, signOut, useSession } from "next-auth/react"
+import { useRouter } from "next/router"
 
 export type UseAuth = () => {
-  handleLogout: () => void;
-  isLoading: boolean;
+  handleLogout: () => void
+  isLoading: boolean
   user?: {
-    name: string;
-    image: string;
-    id: string;
-  };
-  status: "authenticated" | "loading" | "unauthenticated";
-};
+    name: string
+    image: string
+    id: string
+  }
+  status: "authenticated" | "loading" | "unauthenticated"
+}
 
 export const useAuth = () => {
-  const auth = getAuth(firebaseApp);
-  const { data: session, status } = useSession();
-  const { query } = useRouter();
+  const auth = getAuth(firebaseApp)
+  const { data: session, status } = useSession()
+  const { query } = useRouter()
   /**
    * @description ログイン処理
    */
   const handleLogin = useCallback(() => {
-    const queryPrams = new URLSearchParams(window.location.search);
-    const token = queryPrams.get("t");
+    const queryPrams = new URLSearchParams(window.location.search)
+    const token = queryPrams.get("t")
 
     if (token) {
       window.history.replaceState(
         undefined,
         window.document.title,
         window.location.href.replace(window.location.search, "")
-      );
+      )
       signInWithCustomToken(auth, token) // 認証に成功したら ID トークンを NextAuth に渡す
         .then((credential) => credential.user.getIdToken(true))
         .then((idToken) => {
           signIn("credentials", {
             idToken,
-            callbackUrl: `${
-              process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
-            }/events`,
-          });
+            callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/events`,
+          })
         })
-        .catch((err) => console.error(err));
+        .catch((err) => console.error(err))
     }
-  }, [auth]);
+  }, [auth])
   /**
    * @description ログアウト処理
    * @param {React.MouseEvent<HTMLAnchorElement, MouseEvent>} e
    */
   const handleLogout = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
-    e.preventDefault();
+    e.preventDefault()
     signOut({
-      callbackUrl: `${
-        process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"
-      }/login`,
-    });
-  };
+      callbackUrl: `${process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000"}/login`,
+    })
+  }
   useEffect(() => {
-    handleLogin();
-  }, [handleLogin]);
+    handleLogin()
+  }, [handleLogin])
   /**
    * @description ローディングフラグ
    */
-  const isLoading = useMemo(
-    () => status === "loading" || typeof query?.t === "string",
-    [status, query]
-  );
+  const isLoading = useMemo(() => status === "loading" || typeof query?.t === "string", [status, query])
   /**
    * @description ユーザー情報
    */
@@ -74,17 +67,17 @@ export const useAuth = () => {
     () =>
       session?.user as
         | {
-            name: string;
-            image: string;
-            id: string;
+            name: string
+            image: string
+            id: string
           }
         | undefined,
     [session]
-  );
+  )
   return {
     handleLogout,
     isLoading,
     user,
     status,
-  };
-};
+  }
+}

--- a/src/hooks/useRouterQuery.ts
+++ b/src/hooks/useRouterQuery.ts
@@ -1,8 +1,8 @@
-import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useRouter } from "next/router"
+import { useMemo } from "react"
 
 export const useRouterQuery = (key: string) => {
-    const router = useRouter();
-    const queryData = useMemo(() => router.query[key] as string, [router]);
-    return queryData
+  const router = useRouter()
+  const queryData = useMemo(() => router.query[key] as string, [router])
+  return queryData
 }

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,12 +1,12 @@
-import React, { memo, PropsWithChildren, useMemo } from "react"
-import { AppShell } from "@mantine/core"
-import { AppHeader } from "@/features/Header"
+import { AppShell, MantineProvider } from "@mantine/core"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
-import { MantineProvider } from "@mantine/core"
 import Head from "next/head"
+import React, { memo, PropsWithChildren, useMemo } from "react"
+
 import { APP_NAME } from "@/constants"
 import { AppFooter } from "@/features/Footer"
+import { AppHeader } from "@/features/Header"
 
 interface Props {
   title?: string

--- a/src/layouts/Default.tsx
+++ b/src/layouts/Default.tsx
@@ -1,55 +1,50 @@
-import React, { memo, PropsWithChildren, useMemo } from "react";
-import { AppShell } from "@mantine/core";
-import { AppHeader } from "@/features/Header";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { MantineProvider } from "@mantine/core";
-import Head from "next/head";
-import { APP_NAME } from "@/constants";
-import { AppFooter } from "@/features/Footer";
+import React, { memo, PropsWithChildren, useMemo } from "react"
+import { AppShell } from "@mantine/core"
+import { AppHeader } from "@/features/Header"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
+import { MantineProvider } from "@mantine/core"
+import Head from "next/head"
+import { APP_NAME } from "@/constants"
+import { AppFooter } from "@/features/Footer"
 
 interface Props {
-  title?: string;
+  title?: string
 }
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient()
 
-export const DefaultLayout: React.FC<PropsWithChildren<Props>> = memo(
-  ({ children, title = APP_NAME }) => {
-    const seoTitle = useMemo(() => {
-      return title !== APP_NAME ? `${title} | ${APP_NAME}` : APP_NAME;
-    }, [title]);
-    return (
-      <QueryClientProvider client={queryClient}>
-        <MantineProvider
-          withGlobalStyles
-          withNormalizeCSS
-          theme={{
-            fontFamily:
-              '"Helvetica Neue",Arial,"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif',
-          }}
+export const DefaultLayout: React.FC<PropsWithChildren<Props>> = memo(({ children, title = APP_NAME }) => {
+  const seoTitle = useMemo(() => {
+    return title !== APP_NAME ? `${title} | ${APP_NAME}` : APP_NAME
+  }, [title])
+  return (
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider
+        withGlobalStyles
+        withNormalizeCSS
+        theme={{
+          fontFamily: '"Helvetica Neue",Arial,"Hiragino Kaku Gothic ProN","Hiragino Sans",Meiryo,sans-serif',
+        }}
+      >
+        <Head>
+          <title>{seoTitle}</title>
+        </Head>
+        <AppShell
+          padding="md"
+          header={<AppHeader />}
+          footer={<AppFooter />}
+          styles={(theme) => ({
+            main: {
+              backgroundColor: theme.colors.gray[0],
+              minHeight: "100dvh",
+            },
+          })}
         >
-          <Head>
-            <title>{seoTitle}</title>
-          </Head>
-          <AppShell
-            padding="md"
-            header={<AppHeader />}
-            footer={<AppFooter />}
-            styles={(theme) => ({
-              main: {
-                backgroundColor: theme.colors.gray[0],
-                minHeight: "100dvh",
-              },
-            })}
-          >
-            {children}
-          </AppShell>
-        </MantineProvider>
-        {process.env.NODE_ENV === "development" && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )}
-      </QueryClientProvider>
-    );
-  }
-);
+          {children}
+        </AppShell>
+      </MantineProvider>
+      {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  )
+})

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,17 +1,17 @@
-import Axios from "axios";
-import toast from "react-hot-toast";
+import Axios from "axios"
+import toast from "react-hot-toast"
 
 export const axios = Axios.create({
   baseURL: process.env.BASE_URL,
-});
+})
 
 axios.interceptors.response.use(
   (response) => {
-    return response.data;
+    return response.data
   },
   (error) => {
-    const message = error.response?.data?.message || error.message;
-    toast.error(message);
-    return Promise.reject(error);
+    const message = error.response?.data?.message || error.message
+    toast.error(message)
+    return Promise.reject(error)
   }
-);
+)

--- a/src/lib/contentful.ts
+++ b/src/lib/contentful.ts
@@ -1,8 +1,8 @@
-import { createClient } from "contentful-management";
+import { createClient } from "contentful-management"
 
 const client = createClient({
   // This is the access token for this space. Normally you get the token in the Contentful web app
   accessToken: process.env.CONTENTFUL_ACCESS_TOKEN as string,
-});
+})
 
-export default client;
+export default client

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,7 +3,8 @@ import type { FirebaseOptions } from "firebase/app"
 import { getFirestore } from "firebase/firestore"
 
 const firebaseConfig: FirebaseOptions = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  // envファイルを読み込まないCI上で空文字やundefinedだとbuildに失敗するため、適当な文字列を入れておく
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY ?? "sample",
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,6 @@
-import { initializeApp } from "firebase/app";
-import type { FirebaseOptions } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { initializeApp } from "firebase/app"
+import type { FirebaseOptions } from "firebase/app"
+import { getFirestore } from "firebase/firestore"
 
 const firebaseConfig: FirebaseOptions = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -9,8 +9,8 @@ const firebaseConfig: FirebaseOptions = {
   storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
   messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+}
 
-export const firebaseApp = initializeApp(firebaseConfig);
+export const firebaseApp = initializeApp(firebaseConfig)
 
-export const db = getFirestore(firebaseApp);
+export const db = getFirestore(firebaseApp)

--- a/src/lib/firebaseAdmin.ts
+++ b/src/lib/firebaseAdmin.ts
@@ -1,14 +1,14 @@
-import * as admin from "firebase-admin";
-import type { ServiceAccount } from "firebase-admin";
+import * as admin from "firebase-admin"
+import type { ServiceAccount } from "firebase-admin"
 
 const cert: ServiceAccount = {
   projectId: process.env.FIREBASE_PROJECT_ID,
   clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
   privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
-};
+}
 
 export const firebaseAdmin =
   admin.apps[0] ??
   admin.initializeApp({
     credential: admin.credential.cert(cert),
-  });
+  })

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -1,7 +1,6 @@
-
-import { AxiosError } from 'axios';
-import { QueryClient, UseQueryOptions, UseMutationOptions, DefaultOptions } from '@tanstack/react-query';
-import { PromiseValue } from 'type-fest';
+import { AxiosError } from "axios"
+import { QueryClient, UseQueryOptions, UseMutationOptions, DefaultOptions } from "@tanstack/react-query"
+import { PromiseValue } from "type-fest"
 
 const queryConfig: DefaultOptions = {
   queries: {
@@ -9,21 +8,19 @@ const queryConfig: DefaultOptions = {
     refetchOnWindowFocus: false,
     retry: false,
   },
-};
+}
 
-export const queryClient = new QueryClient({ defaultOptions: queryConfig });
+export const queryClient = new QueryClient({ defaultOptions: queryConfig })
 
-export type ExtractFnReturnType<FnType extends (...args: any) => any> = PromiseValue<
-  ReturnType<FnType>
->;
+export type ExtractFnReturnType<FnType extends (...args: any) => any> = PromiseValue<ReturnType<FnType>>
 
 export type QueryConfig<QueryFnType extends (...args: any) => any> = Omit<
   UseQueryOptions<ExtractFnReturnType<QueryFnType>>,
-  'queryKey' | 'queryFn'
->;
+  "queryKey" | "queryFn"
+>
 
 export type MutationConfig<MutationFnType extends (...args: any) => any> = UseMutationOptions<
   ExtractFnReturnType<MutationFnType>,
   AxiosError,
   Parameters<MutationFnType>[0]
->;
+>

--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -1,5 +1,5 @@
-import { AxiosError } from "axios"
 import { QueryClient, UseQueryOptions, UseMutationOptions, DefaultOptions } from "@tanstack/react-query"
+import { AxiosError } from "axios"
 import { PromiseValue } from "type-fest"
 
 const queryConfig: DefaultOptions = {

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,5 +1,6 @@
-import axios from "axios"
 import * as qs from "querystring"
+
+import axios from "axios"
 
 export type oauthAccessResponseType = {
   user_id: string

--- a/src/lib/slack.ts
+++ b/src/lib/slack.ts
@@ -1,13 +1,13 @@
-import axios from "axios";
-import * as qs from "querystring";
+import axios from "axios"
+import * as qs from "querystring"
 
 export type oauthAccessResponseType = {
-  user_id: string;
-  access_token: string;
-  scope: string;
-  team_name: string;
-  team_id: string;
-};
+  user_id: string
+  access_token: string
+  scope: string
+  team_name: string
+  team_id: string
+}
 
 const slackClient = axios.create({
   baseURL: "https://slack.com/api",
@@ -15,101 +15,89 @@ const slackClient = axios.create({
     "Content-Type": "application/x-www-form-urlencoded",
   },
   transformRequest: [(data) => qs.stringify(data)],
-});
+})
 
 // 認証情報にアクセスする
-export const oauthAccess = async (
-  code: string
-): Promise<oauthAccessResponseType> => {
+export const oauthAccess = async (code: string): Promise<oauthAccessResponseType> => {
   const requestArgs = {
     client_id: process.env.NEXT_PUBLIC_SLACK_CLIENT_ID as string,
     client_secret: process.env.SLACK_CLIENT_SECRET as string,
     code,
-  };
+  }
 
   try {
-    const res = await slackClient.post<oauthAccessResponseType>(
-      "oauth.access",
-      requestArgs
-    );
-    return res.data;
+    const res = await slackClient.post<oauthAccessResponseType>("oauth.access", requestArgs)
+    return res.data
   } catch (err) {
-    console.warn("Slack oauth was failed.", err);
-    throw new Error(
-      err instanceof Error ? err.message : "Slack oauth was failed."
-    );
+    console.warn("Slack oauth was failed.", err)
+    throw new Error(err instanceof Error ? err.message : "Slack oauth was failed.")
   }
-};
+}
 
 export type SlackUserType = {
-  id: string;
-  team_id: string;
-  name: string;
-  deleted: false;
-  color: string;
-  real_name: string;
-  tz: string;
-  tz_label: string;
-  tz_offset: number;
+  id: string
+  team_id: string
+  name: string
+  deleted: false
+  color: string
+  real_name: string
+  tz: string
+  tz_label: string
+  tz_offset: number
   profile: {
-    title: string;
-    phone: string;
-    skype: string;
-    real_name: string;
-    real_name_normalized: string;
-    display_name: string;
-    display_name_normalized: string;
-    fields: unknown;
-    status_text: string;
-    status_emoji: string;
-    status_emoji_display_info: unknown[];
-    status_expiration: number;
-    avatar_hash: string;
-    image_original: string;
-    is_custom_image: boolean;
-    huddle_state: string;
-    first_name: string;
-    last_name: string;
-    image_24: string;
-    image_32: string;
-    image_48: string;
-    image_72: string;
-    image_192: string;
-    image_512: string;
-    image_1024: string;
-    status_text_canonical: string;
-    team: string;
-  };
-  is_admin: boolean;
-  is_owner: boolean;
-  is_primary_owner: boolean;
-  is_restricted: boolean;
-  is_ultra_restricted: boolean;
-  is_bot: boolean;
-  is_app_user: boolean;
-  updated: number;
-  is_email_confirmed: boolean;
-  has_2fa: boolean;
-  who_can_share_contact_card: string;
-};
+    title: string
+    phone: string
+    skype: string
+    real_name: string
+    real_name_normalized: string
+    display_name: string
+    display_name_normalized: string
+    fields: unknown
+    status_text: string
+    status_emoji: string
+    status_emoji_display_info: unknown[]
+    status_expiration: number
+    avatar_hash: string
+    image_original: string
+    is_custom_image: boolean
+    huddle_state: string
+    first_name: string
+    last_name: string
+    image_24: string
+    image_32: string
+    image_48: string
+    image_72: string
+    image_192: string
+    image_512: string
+    image_1024: string
+    status_text_canonical: string
+    team: string
+  }
+  is_admin: boolean
+  is_owner: boolean
+  is_primary_owner: boolean
+  is_restricted: boolean
+  is_ultra_restricted: boolean
+  is_bot: boolean
+  is_app_user: boolean
+  updated: number
+  is_email_confirmed: boolean
+  has_2fa: boolean
+  who_can_share_contact_card: string
+}
 
 // ユーザー情報を取得する
 export const getUserInfo = async (token: string, userId: string) => {
   const requestArgs = {
     token,
     user: userId,
-  };
+  }
 
   try {
-    const res = await slackClient.post<{ user: SlackUserType }>(
-      "users.info",
-      requestArgs
-    );
-    return res.data.user;
+    const res = await slackClient.post<{ user: SlackUserType }>("users.info", requestArgs)
+    return res.data.user
   } catch (err) {
-    console.warn("Slack oauth was failed.", err);
-    throw new Error(
-      err instanceof Error ? err.message : "Slack oauth was failed."
-    );
+    console.warn("Slack oauth was failed.", err)
+    throw new Error(err instanceof Error ? err.message : "Slack oauth was failed.")
   }
-};
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,32 +1,29 @@
-import { SessionProvider } from "next-auth/react";
-import { useEffect } from "react";
-import type { NextPage } from "next";
-import type { AppProps } from "next/app";
-import type { ReactElement, ReactNode } from "react";
-import { Toaster } from "react-hot-toast";
+import { SessionProvider } from "next-auth/react"
+import { useEffect } from "react"
+import type { NextPage } from "next"
+import type { AppProps } from "next/app"
+import type { ReactElement, ReactNode } from "react"
+import { Toaster } from "react-hot-toast"
 
 type NextPageWithLayout = NextPage & {
-  getLayout?: (page: ReactElement) => ReactNode;
-};
+  getLayout?: (page: ReactElement) => ReactNode
+}
 
 type AppPropsWithLayout = AppProps & {
-  Component: NextPageWithLayout;
-};
+  Component: NextPageWithLayout
+}
 
-export default function MyApp({
-  Component,
-  pageProps,
-}: AppPropsWithLayout): ReactNode {
+export default function MyApp({ Component, pageProps }: AppPropsWithLayout): ReactNode {
   useEffect(() => {
-    document.documentElement.style.visibility = "visible";
-  }, []);
+    document.documentElement.style.visibility = "visible"
+  }, [])
   // Use the layout defined at the page level, if available
-  const getLayout = Component.getLayout ?? ((page) => page);
+  const getLayout = Component.getLayout ?? ((page) => page)
 
   return getLayout(
     <SessionProvider session={pageProps?.session}>
       <Component {...pageProps} />
       <Toaster />
     </SessionProvider>
-  );
+  )
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
-import { SessionProvider } from "next-auth/react"
-import { useEffect } from "react"
 import type { NextPage } from "next"
+import { SessionProvider } from "next-auth/react"
 import type { AppProps } from "next/app"
+import { useEffect } from "react"
 import type { ReactElement, ReactNode } from "react"
 import { Toaster } from "react-hot-toast"
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,10 +1,10 @@
-import { createGetInitialProps } from '@mantine/next';
-import Document, { Head, Html, Main, NextScript } from 'next/document';
+import { createGetInitialProps } from "@mantine/next"
+import Document, { Head, Html, Main, NextScript } from "next/document"
 
-const getInitialProps = createGetInitialProps();
+const getInitialProps = createGetInitialProps()
 
 export default class _Document extends Document {
-  static getInitialProps = getInitialProps;
+  static getInitialProps = getInitialProps
 
   render() {
     return (
@@ -15,6 +15,6 @@ export default class _Document extends Document {
           <NextScript />
         </body>
       </Html>
-    );
+    )
   }
 }

--- a/src/pages/api/auth-slack.ts
+++ b/src/pages/api/auth-slack.ts
@@ -1,55 +1,45 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import { firebaseAdmin } from "@/lib/firebaseAdmin";
-import { getUserInfo, oauthAccess } from "@/lib/slack";
+import type { NextApiRequest, NextApiResponse } from "next"
+import { firebaseAdmin } from "@/lib/firebaseAdmin"
+import { getUserInfo, oauthAccess } from "@/lib/slack"
 
-export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // GET
   if (req.method === "GET") {
-    const slackAuthCode = req.query.code;
-    const redirectUri = req.query.state as string | undefined;
+    const slackAuthCode = req.query.code
+    const redirectUri = req.query.state as string | undefined
 
     if (!slackAuthCode) {
-      console.warn("code query string not find.");
-      return res.status(400);
+      console.warn("code query string not find.")
+      return res.status(400)
     }
 
-    const userCredential = await oauthAccess(slackAuthCode as string);
+    const userCredential = await oauthAccess(slackAuthCode as string)
 
     try {
-      const user = await getUserInfo(
-        userCredential.access_token,
-        userCredential.user_id
-      );
+      const user = await getUserInfo(userCredential.access_token, userCredential.user_id)
       // reference: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
       const additionalClaim = {
         name: user.profile.display_name,
         picture: user.profile.image_original,
         sub: user.id,
-      };
-      const customToken = await firebaseAdmin
-        .auth()
-        .createCustomToken(userCredential.user_id, additionalClaim);
+      }
+      const customToken = await firebaseAdmin.auth().createCustomToken(userCredential.user_id, additionalClaim)
 
       if (redirectUri) {
-        const url = new URL(redirectUri);
-        url.search = `t=${customToken}`;
-        return res.redirect(303, url.toString());
+        const url = new URL(redirectUri)
+        url.search = `t=${customToken}`
+        return res.redirect(303, url.toString())
       } else {
         return res.json({
           custom_token: customToken,
           user,
-        });
+        })
       }
     } catch (err) {
-      return res
-        .status(500)
-        .json(err instanceof Error ? err.message : "エラーが発生しました");
+      return res.status(500).json(err instanceof Error ? err.message : "エラーが発生しました")
     }
   } else {
-    res.setHeader("Allow", "GET");
-    return res.status(405).end("Method Not Allowed");
+    res.setHeader("Allow", "GET")
+    return res.status(405).end("Method Not Allowed")
   }
 }

--- a/src/pages/api/auth-slack.ts
+++ b/src/pages/api/auth-slack.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next"
+
 import { firebaseAdmin } from "@/lib/firebaseAdmin"
 import { getUserInfo, oauthAccess } from "@/lib/slack"
 

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -1,37 +1,37 @@
 // reference: https://github.com/nextauthjs/next-auth-typescript-example/blob/main/pages/api/auth/%5B...nextauth%5D.ts
-import NextAuth from "next-auth";
-import CredentialsProvider from "next-auth/providers/credentials";
-import { firebaseAdmin } from "../../../lib/firebaseAdmin";
+import NextAuth from "next-auth"
+import CredentialsProvider from "next-auth/providers/credentials"
+import { firebaseAdmin } from "../../../lib/firebaseAdmin"
 
 export default NextAuth({
   providers: [
     CredentialsProvider({
       authorize: async (credentials, req) => {
-        const idToken = credentials?.idToken;
+        const idToken = credentials?.idToken
         if (idToken) {
           try {
-            const decoded = await firebaseAdmin.auth().verifyIdToken(idToken);
-            return { ...decoded };
+            const decoded = await firebaseAdmin.auth().verifyIdToken(idToken)
+            return { ...decoded }
           } catch (error) {
-            console.error("Failed to verify ID token:", error);
+            console.error("Failed to verify ID token:", error)
           }
         }
-        return null;
+        return null
       },
     }),
   ],
   callbacks: {
     session: async ({ session, token }) => {
       if (session?.user) {
-        session.user.id = token.uid;
+        session.user.id = token.uid
       }
-      return session;
+      return session
     },
     jwt: async ({ token, user }) => {
       if (user) {
-        return user;
+        return user
       }
-      return token;
+      return token
     },
   },
-});
+})

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -1,6 +1,7 @@
 // reference: https://github.com/nextauthjs/next-auth-typescript-example/blob/main/pages/api/auth/%5B...nextauth%5D.ts
 import NextAuth from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
+
 import { firebaseAdmin } from "../../../lib/firebaseAdmin"
 
 export default NextAuth({

--- a/src/pages/api/document-detail.ts
+++ b/src/pages/api/document-detail.ts
@@ -1,11 +1,12 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next"
-import { db } from "@/lib/firebase"
 import { doc, getDoc, setDoc } from "firebase/firestore"
-import { BaseResponse, DocumentId, EventId } from "@/types"
-import { uploadFileToContentful } from "@/features/documents/functions/uploadFile"
-import { DocumentData } from "@/types/document"
+import type { NextApiRequest, NextApiResponse } from "next"
+
 import { getFileFromContentful } from "@/features/documents/functions/getFile"
+import { uploadFileToContentful } from "@/features/documents/functions/uploadFile"
+import { db } from "@/lib/firebase"
+import { BaseResponse, DocumentId, EventId } from "@/types"
+import { DocumentData } from "@/types/document"
 
 type EventRequest = NextApiRequest & {
   query: {

--- a/src/pages/api/document-detail.ts
+++ b/src/pages/api/document-detail.ts
@@ -1,19 +1,19 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next";
-import { db } from "@/lib/firebase";
-import { doc, getDoc, setDoc } from "firebase/firestore";
-import { BaseResponse, DocumentId, EventId } from "@/types";
-import { uploadFileToContentful } from "@/features/documents/functions/uploadFile";
-import { DocumentData } from "@/types/document";
-import { getFileFromContentful } from "@/features/documents/functions/getFile";
+import type { NextApiRequest, NextApiResponse } from "next"
+import { db } from "@/lib/firebase"
+import { doc, getDoc, setDoc } from "firebase/firestore"
+import { BaseResponse, DocumentId, EventId } from "@/types"
+import { uploadFileToContentful } from "@/features/documents/functions/uploadFile"
+import { DocumentData } from "@/types/document"
+import { getFileFromContentful } from "@/features/documents/functions/getFile"
 
 type EventRequest = NextApiRequest & {
   query: {
-    eventId: EventId | undefined;
-    documentId: DocumentId | undefined;
-  };
-  body: DocumentData;
-};
+    eventId: EventId | undefined
+    documentId: DocumentId | undefined
+  }
+  body: DocumentData
+}
 
 export const config = {
   api: {
@@ -21,34 +21,25 @@ export const config = {
       sizeLimit: "4mb", // Set desired value here
     },
   },
-};
+}
 
-export default async function handler(
-  req: EventRequest,
-  res: NextApiResponse<DocumentData | BaseResponse>
-) {
+export default async function handler(req: EventRequest, res: NextApiResponse<DocumentData | BaseResponse>) {
   if (req.method === "GET") {
     if (!req.query.eventId || !req.query.documentId) {
-      return res.status(400).end("Bad request. Some parameter is missing.");
+      return res.status(400).end("Bad request. Some parameter is missing.")
     }
-    let data: any = {};
+    let data: any = {}
     const docSnap = await getDoc(
-      doc(
-        db,
-        "study-group-list",
-        req.query.eventId as string,
-        "documents",
-        req.query.documentId as string
-      )
-    );
+      doc(db, "study-group-list", req.query.eventId as string, "documents", req.query.documentId as string)
+    )
     if (docSnap.exists()) {
-      data = docSnap.data();
+      data = docSnap.data()
     }
     if (!!Object.keys(data).length && data.file) {
-      const asset = await getFileFromContentful({ id: data.file });
-      data.file = asset;
+      const asset = await getFileFromContentful({ id: data.file })
+      data.file = asset
     }
-    return res.status(200).json(data);
+    return res.status(200).json(data)
   }
   if (req.method === "POST") {
     if (
@@ -60,7 +51,7 @@ export default async function handler(
       req.body.name === undefined ||
       req.body.title === undefined
     ) {
-      return res.status(400).end("Bad request. Some parameter is missing.");
+      return res.status(400).end("Bad request. Some parameter is missing.")
     }
     let docParams = {
       emoji: req.body.emoji,
@@ -68,32 +59,23 @@ export default async function handler(
       url: req.body.url,
       name: req.body.name,
       title: req.body.title,
-    };
+    }
     // contentfulにアップロード
     if (req.body.file.data && req.body.file.type) {
       const asset = await uploadFileToContentful({
         data: req.body.file.data,
         extension: req.body.file.type,
         title: req.body.title,
-      });
-      docParams.file = asset.sys.id;
+      })
+      docParams.file = asset.sys.id
     }
     // データがあればfirestoreにアップロード
     if (docParams.file || docParams.url) {
-      await setDoc(
-        doc(
-          db,
-          "study-group-list",
-          req.body.target_event,
-          "documents",
-          req.body.user_id
-        ),
-        docParams
-      );
+      await setDoc(doc(db, "study-group-list", req.body.target_event, "documents", req.body.user_id), docParams)
     }
-    res.status(200).json({ status: "ok" });
+    res.status(200).json({ status: "ok" })
   } else {
-    res.setHeader("Allow", ["GET", "POST", "PUT"]);
-    res.status(405).end("Method Not Allowed");
+    res.setHeader("Allow", ["GET", "POST", "PUT"])
+    res.status(405).end("Method Not Allowed")
   }
 }

--- a/src/pages/api/event-collection.ts
+++ b/src/pages/api/event-collection.ts
@@ -1,7 +1,8 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next"
-import { db } from "@/lib/firebase"
 import { collection, getDocs, orderBy, query } from "firebase/firestore"
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { db } from "@/lib/firebase"
 import { EventId, UserId } from "@/types"
 import { DocumentData } from "@/types/document"
 

--- a/src/pages/api/event-collection.ts
+++ b/src/pages/api/event-collection.ts
@@ -1,30 +1,26 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next";
-import { db } from "@/lib/firebase";
-import { collection, getDocs, orderBy, query } from "firebase/firestore";
-import { EventId, UserId } from "@/types";
-import { DocumentData } from "@/types/document";
+import type { NextApiRequest, NextApiResponse } from "next"
+import { db } from "@/lib/firebase"
+import { collection, getDocs, orderBy, query } from "firebase/firestore"
+import { EventId, UserId } from "@/types"
+import { DocumentData } from "@/types/document"
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Record<EventId, Record<UserId, DocumentData>>>
 ) {
-  const data: Record<string, any> = {};
-  const querySnapshot = await getDocs(
-    query(collection(db, "study-group-list"), orderBy("createdAt", "desc"))
-  );
+  const data: Record<string, any> = {}
+  const querySnapshot = await getDocs(query(collection(db, "study-group-list"), orderBy("createdAt", "desc")))
   await Promise.all(
     querySnapshot.docs.map(async (doc) => {
-      data[doc.id] = {};
-      const subQuerySnapshot = await getDocs(
-        collection(db, "study-group-list", doc.id, "documents")
-      );
+      data[doc.id] = {}
+      const subQuerySnapshot = await getDocs(collection(db, "study-group-list", doc.id, "documents"))
       await Promise.all(
         subQuerySnapshot.docs.map((subDoc) => {
-          data[doc.id][subDoc.id] = subDoc.data();
+          data[doc.id][subDoc.id] = subDoc.data()
         })
-      );
+      )
     })
-  );
-  res.status(200).json(data);
+  )
+  res.status(200).json(data)
 }

--- a/src/pages/api/event-detail.ts
+++ b/src/pages/api/event-detail.ts
@@ -1,31 +1,26 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next";
-import { db } from "@/lib/firebase";
-import { collection, getDocs } from "firebase/firestore";
-import { UserId } from "@/types";
-import { DocumentData } from "@/types/document";
+import type { NextApiRequest, NextApiResponse } from "next"
+import { db } from "@/lib/firebase"
+import { collection, getDocs } from "firebase/firestore"
+import { UserId } from "@/types"
+import { DocumentData } from "@/types/document"
 
 type EventGetRequest = NextApiRequest & {
   query: {
-    eventId: string | undefined;
-  };
-};
-
-export default async function handler(
-  req: EventGetRequest,
-  res: NextApiResponse<Record<UserId, DocumentData>>
-) {
-  if (!req.query.eventId) {
-    return res.status(400);
+    eventId: string | undefined
   }
-  const data: Record<string, any> = {};
-  const querySnapshot = await getDocs(
-    collection(db, "study-group-list", req.query.eventId as string, "documents")
-  );
+}
+
+export default async function handler(req: EventGetRequest, res: NextApiResponse<Record<UserId, DocumentData>>) {
+  if (!req.query.eventId) {
+    return res.status(400)
+  }
+  const data: Record<string, any> = {}
+  const querySnapshot = await getDocs(collection(db, "study-group-list", req.query.eventId as string, "documents"))
   await Promise.all(
     querySnapshot.docs.map((doc) => {
-      data[doc.id] = doc.data();
+      data[doc.id] = doc.data()
     })
-  );
-  res.status(200).json(data);
+  )
+  res.status(200).json(data)
 }

--- a/src/pages/api/event-detail.ts
+++ b/src/pages/api/event-detail.ts
@@ -1,7 +1,8 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from "next"
-import { db } from "@/lib/firebase"
 import { collection, getDocs } from "firebase/firestore"
+import type { NextApiRequest, NextApiResponse } from "next"
+
+import { db } from "@/lib/firebase"
 import { UserId } from "@/types"
 import { DocumentData } from "@/types/document"
 

--- a/src/pages/events/[eventId]/documents/[documentId].tsx
+++ b/src/pages/events/[eventId]/documents/[documentId].tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
-import { DefaultLayout } from "@/layouts/Default"
+
 import { DocumentDetailPage } from "@/features/misc/pages/DocumentDetail"
+import { DefaultLayout } from "@/layouts/Default"
 
 const DocumentDetail = (): JSX.Element => {
   return <DocumentDetailPage />

--- a/src/pages/events/[eventId]/documents/[documentId].tsx
+++ b/src/pages/events/[eventId]/documents/[documentId].tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from "react";
-import { DefaultLayout } from "@/layouts/Default";
-import { DocumentDetailPage } from "@/features/misc/pages/DocumentDetail";
+import React, { ReactElement } from "react"
+import { DefaultLayout } from "@/layouts/Default"
+import { DocumentDetailPage } from "@/features/misc/pages/DocumentDetail"
 
 const DocumentDetail = (): JSX.Element => {
-  return <DocumentDetailPage />;
-};
+  return <DocumentDetailPage />
+}
 
 DocumentDetail.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout title="LT資料">{page}</DefaultLayout>;
-};
+  return <DefaultLayout title="LT資料">{page}</DefaultLayout>
+}
 
-export default DocumentDetail;
+export default DocumentDetail

--- a/src/pages/events/[eventId]/index.tsx
+++ b/src/pages/events/[eventId]/index.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react"
-import { DefaultLayout } from "@/layouts/Default"
+
 import { EventDetailPage } from "@/features/misc/pages/EventDetail"
+import { DefaultLayout } from "@/layouts/Default"
 
 const EventDetail = (): JSX.Element => {
   return <EventDetailPage />

--- a/src/pages/events/[eventId]/index.tsx
+++ b/src/pages/events/[eventId]/index.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from "react";
-import { DefaultLayout } from "@/layouts/Default";
-import { EventDetailPage } from "@/features/misc/pages/EventDetail";
+import React, { ReactElement } from "react"
+import { DefaultLayout } from "@/layouts/Default"
+import { EventDetailPage } from "@/features/misc/pages/EventDetail"
 
 const EventDetail = (): JSX.Element => {
-  return <EventDetailPage />;
-};
+  return <EventDetailPage />
+}
 
 EventDetail.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout title="勉強会詳細">{page}</DefaultLayout>;
-};
+  return <DefaultLayout title="勉強会詳細">{page}</DefaultLayout>
+}
 
-export default EventDetail;
+export default EventDetail

--- a/src/pages/events/[eventId]/upload.tsx
+++ b/src/pages/events/[eventId]/upload.tsx
@@ -1,15 +1,13 @@
-import { DocumentUploadPage } from "@/features/misc/pages/DocumentUpload";
-import { DefaultLayout } from "@/layouts/Default";
-import React, { ReactElement,  } from "react";
+import { DocumentUploadPage } from "@/features/misc/pages/DocumentUpload"
+import { DefaultLayout } from "@/layouts/Default"
+import React, { ReactElement } from "react"
 
 const Upload = (): JSX.Element => {
-  return (
-    <DocumentUploadPage />
-  );
-};
+  return <DocumentUploadPage />
+}
 
 Upload.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout title="資料の追加">{page}</DefaultLayout>;
-};
+  return <DefaultLayout title="資料の追加">{page}</DefaultLayout>
+}
 
-export default Upload;
+export default Upload

--- a/src/pages/events/[eventId]/upload.tsx
+++ b/src/pages/events/[eventId]/upload.tsx
@@ -1,6 +1,7 @@
+import React, { ReactElement } from "react"
+
 import { DocumentUploadPage } from "@/features/misc/pages/DocumentUpload"
 import { DefaultLayout } from "@/layouts/Default"
-import React, { ReactElement } from "react"
 
 const Upload = (): JSX.Element => {
   return <DocumentUploadPage />

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement } from "react"
+
 import { EventListPage } from "@/features/misc/pages/EventList"
 import { DefaultLayout } from "@/layouts/Default"
 

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -1,13 +1,13 @@
-import React, { ReactElement } from "react";
-import { EventListPage } from "@/features/misc/pages/EventList";
-import { DefaultLayout } from "@/layouts/Default";
+import React, { ReactElement } from "react"
+import { EventListPage } from "@/features/misc/pages/EventList"
+import { DefaultLayout } from "@/layouts/Default"
 
 const Events = (): JSX.Element => {
-  return <EventListPage />;
-};
+  return <EventListPage />
+}
 
 Events.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout title="勉強会一覧">{page}</DefaultLayout>;
-};
+  return <DefaultLayout title="勉強会一覧">{page}</DefaultLayout>
+}
 
-export default Events;
+export default Events

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import { DefaultLayout } from "@/layouts/Default";
-import { ReactElement } from "react";
-import { IndexPage } from "@/features/misc/pages/Index";
+import React from "react"
+import { DefaultLayout } from "@/layouts/Default"
+import { ReactElement } from "react"
+import { IndexPage } from "@/features/misc/pages/Index"
 
 const Index = (): JSX.Element => {
   return <IndexPage />
-};
+}
 
 Index.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout>{page}</DefaultLayout>;
-};
+  return <DefaultLayout>{page}</DefaultLayout>
+}
 
-export default Index;
+export default Index

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
-import React from "react"
-import { DefaultLayout } from "@/layouts/Default"
-import { ReactElement } from "react"
+import React, { ReactElement } from "react"
+
 import { IndexPage } from "@/features/misc/pages/Index"
+import { DefaultLayout } from "@/layouts/Default"
 
 const Index = (): JSX.Element => {
   return <IndexPage />

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,13 +1,13 @@
-import { DefaultLayout } from "@/layouts/Default";
-import React, { ReactElement } from "react";
-import { LoginPage } from "@/features/misc/pages/Login";
+import { DefaultLayout } from "@/layouts/Default"
+import React, { ReactElement } from "react"
+import { LoginPage } from "@/features/misc/pages/Login"
 
 const Login = (): JSX.Element => {
   return <LoginPage />
-};
+}
 
 Login.getLayout = function getLayout(page: ReactElement) {
-  return <DefaultLayout title="ログイン">{page}</DefaultLayout>;
-};
+  return <DefaultLayout title="ログイン">{page}</DefaultLayout>
+}
 
-export default Login;
+export default Login

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,7 @@
-import { DefaultLayout } from "@/layouts/Default"
 import React, { ReactElement } from "react"
+
 import { LoginPage } from "@/features/misc/pages/Login"
+import { DefaultLayout } from "@/layouts/Default"
 
 const Login = (): JSX.Element => {
   return <LoginPage />

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -1,8 +1,8 @@
 export type DocumentData = {
-  name: string;
-  user_id: string;
-  file: string | null;
-  url: string | null;
-  title: string;
-  emoji: string;
-};
+  name: string
+  user_id: string
+  file: string | null
+  url: string | null
+  title: string
+  emoji: string
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export type BaseResponse = {
-  status: string;
-};
+  status: string
+}
 
-export type UserId = string;
-export type EventId = string;
-export type DocumentId = string;
+export type UserId = string
+export type EventId = string
+export type DocumentId = string

--- a/yarn.lock
+++ b/yarn.lock
@@ -3761,6 +3761,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prettier@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.1.tgz#4e1fd11c34e2421bc1da9aea9bd8127cd0a35efc"
+  integrity sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==
+
 pretty-format@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,19 +96,26 @@
     "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/runtime-corejs3@^7.10.2":
-  version "7.20.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.20.1.tgz#d0775a49bb5fba77e42cbb7276c9955c7b05af8d"
-  integrity sha512-CGulbEDcg/ND1Im7fUNRZdGXmX2MTWVVZacQi/6DiKE5HNwZ3aVTm5PV4lO8HHz0B2h8WQyvKKjbX5XgTtydsg==
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.20.6.tgz#63dae945963539ab0ad578efbf3eff271e7067ae"
+  integrity sha512-tqeujPiuEfcH067mx+7otTQWROVMKHXEaOQcAeNV5dDdbPWvPcFA8/W9LXw2NfjNmOetqLl03dfnG2WALPlsRQ==
   dependencies:
     core-js-pure "^3.25.1"
-    regenerator-runtime "^0.13.10"
+    regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
   integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
   dependencies:
     regenerator-runtime "^0.13.10"
+
+"@babel/runtime@^7.18.9":
+  version "7.20.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.6.tgz#facf4879bfed9b5326326273a64220f099b0fce3"
+  integrity sha512-Q+8MqP7TiHMWzSfwiJwXCjyf4GYA4Dgw3emg/7xmwsdLJOZUp+nMqcOwOzzYheuM1rhDu8FSj2l0aoMygEuXuA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
 
 "@babel/template@^7.18.10":
   version "7.18.10"
@@ -1322,47 +1329,47 @@
     "@types/node" "*"
 
 "@typescript-eslint/parser@^5.42.0":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.42.1.tgz#3e66156f2f74b11690b45950d8f5f28a62751d35"
-  integrity sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.46.0.tgz#002d8e67122947922a62547acfed3347cbf2c0b6"
+  integrity sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.42.1"
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/typescript-estree" "5.42.1"
+    "@typescript-eslint/scope-manager" "5.46.0"
+    "@typescript-eslint/types" "5.46.0"
+    "@typescript-eslint/typescript-estree" "5.46.0"
     debug "^4.3.4"
 
-"@typescript-eslint/scope-manager@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz#05e5e1351485637d466464237e5259b49f609b18"
-  integrity sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==
+"@typescript-eslint/scope-manager@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.46.0.tgz#60790b14d0c687dd633b22b8121374764f76ce0d"
+  integrity sha512-7wWBq9d/GbPiIM6SqPK9tfynNxVbfpihoY5cSFMer19OYUA3l4powA2uv0AV2eAZV6KoAh6lkzxv4PoxOLh1oA==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/visitor-keys" "5.42.1"
+    "@typescript-eslint/types" "5.46.0"
+    "@typescript-eslint/visitor-keys" "5.46.0"
 
-"@typescript-eslint/types@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.42.1.tgz#0d4283c30e9b70d2aa2391c36294413de9106df2"
-  integrity sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==
+"@typescript-eslint/types@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.46.0.tgz#f4d76622a996b88153bbd829ea9ccb9f7a5d28bc"
+  integrity sha512-wHWgQHFB+qh6bu0IAPAJCdeCdI0wwzZnnWThlmHNY01XJ9Z97oKqKOzWYpR2I83QmshhQJl6LDM9TqMiMwJBTw==
 
-"@typescript-eslint/typescript-estree@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz#f9a223ecb547a781d37e07a5ac6ba9ff681eaef0"
-  integrity sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==
+"@typescript-eslint/typescript-estree@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.0.tgz#a6c2b84b9351f78209a1d1f2d99ca553f7fa29a5"
+  integrity sha512-kDLNn/tQP+Yp8Ro2dUpyyVV0Ksn2rmpPpB0/3MO874RNmXtypMwSeazjEN/Q6CTp8D7ExXAAekPEcCEB/vtJkw==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
-    "@typescript-eslint/visitor-keys" "5.42.1"
+    "@typescript-eslint/types" "5.46.0"
+    "@typescript-eslint/visitor-keys" "5.46.0"
     debug "^4.3.4"
     globby "^11.1.0"
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@5.42.1":
-  version "5.42.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz#df10839adf6605e1cdb79174cf21e46df9be4872"
-  integrity sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==
+"@typescript-eslint/visitor-keys@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.0.tgz#36d87248ae20c61ef72404bcd61f14aa2563915f"
+  integrity sha512-E13gBoIXmaNhwjipuvQg1ByqSAu/GbEpP/qzFihugJ+MomtoJtFAJG/+2DRPByf57B863m0/q7Zt16V9ohhANw==
   dependencies:
-    "@typescript-eslint/types" "5.42.1"
+    "@typescript-eslint/types" "5.46.0"
     eslint-visitor-keys "^3.3.0"
 
 abort-controller@^3.0.0:
@@ -1438,7 +1445,7 @@ aria-query@^4.2.2:
     "@babel/runtime" "^7.10.2"
     "@babel/runtime-corejs3" "^7.10.2"
 
-array-includes@^3.1.4, array-includes@^3.1.5:
+array-includes@^3.1.4, array-includes@^3.1.5, array-includes@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.6.tgz#9e9e720e194f198266ba9e18c29e6a9b0e4b225f"
   integrity sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==
@@ -1464,7 +1471,7 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
-array.prototype.flatmap@^1.3.0:
+array.prototype.flatmap@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flatmap/-/array.prototype.flatmap-1.3.1.tgz#1aae7903c2100433cb8261cd4ed310aab5c4a183"
   integrity sha512-8UGn9O1FDVvMNB0UlLv4voxRMze7+FpHyF5mSMRjWHUMlpoDViniy05870VlxhfgTnLbpuwTzvD76MTtWxB/mQ==
@@ -1473,6 +1480,17 @@ array.prototype.flatmap@^1.3.0:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
+
+array.prototype.tosorted@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz#ccf44738aa2b5ac56578ffda97c03fd3e23dd532"
+  integrity sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.4"
+    es-abstract "^1.20.4"
+    es-shim-unscopables "^1.0.0"
+    get-intrinsic "^1.1.3"
 
 arrify@^2.0.0:
   version "2.0.1"
@@ -1507,9 +1525,9 @@ attr-accept@^2.2.2:
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
 
 axe-core@^4.4.3:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.5.1.tgz#04d561c11b6d76d096d34e9d14ba2c294fb20cdc"
-  integrity sha512-1exVbW0X1O/HSr/WMwnaweyqcWOgZgLiVxdLG34pvSQk4NlYQr9OUy0JLwuhFfuVNQzzqgH57eYzkFBCb3bIsQ==
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.5.2.tgz#823fdf491ff717ac3c58a52631d4206930c1d9f7"
+  integrity sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==
 
 axios@^0.27.1:
   version "0.27.2"
@@ -1759,9 +1777,9 @@ copy-anything@^3.0.2:
     is-what "^4.1.6"
 
 core-js-pure@^3.25.1:
-  version "3.26.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.0.tgz#7ad8a5dd7d910756f3124374b50026e23265ca9a"
-  integrity sha512-LiN6fylpVBVwT8twhhluD9TzXmZQQsr2I2eIKtWNbZI1XMfBT7CV18itaN6RA7EtQd/SDdRx/wzvAShX2HvhQA==
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.1.tgz#653f4d7130c427820dcecd3168b594e8bb095a33"
+  integrity sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -1993,9 +2011,9 @@ error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.19.0, es-abstract@^1.20.4:
-  version "1.20.4"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.4.tgz#1d103f9f8d78d4cf0713edcd6d0ed1a46eed5861"
-  integrity sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==
+  version "1.20.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.20.5.tgz#e6dc99177be37cacda5988e692c3fa8b218e95d2"
+  integrity sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -2003,6 +2021,7 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     function.prototype.name "^1.1.5"
     get-intrinsic "^1.1.3"
     get-symbol-description "^1.0.0"
+    gopd "^1.0.1"
     has "^1.0.3"
     has-property-descriptors "^1.0.0"
     has-symbols "^1.0.3"
@@ -2018,8 +2037,8 @@ es-abstract@^1.19.0, es-abstract@^1.20.4:
     object.assign "^4.1.4"
     regexp.prototype.flags "^1.4.3"
     safe-regex-test "^1.0.0"
-    string.prototype.trimend "^1.0.5"
-    string.prototype.trimstart "^1.0.5"
+    string.prototype.trimend "^1.0.6"
+    string.prototype.trimstart "^1.0.6"
     unbox-primitive "^1.0.2"
 
 es-shim-unscopables@^1.0.0:
@@ -2084,6 +2103,11 @@ eslint-config-next@13.0.3:
     eslint-plugin-jsx-a11y "^6.5.1"
     eslint-plugin-react "^7.31.7"
     eslint-plugin-react-hooks "^4.5.0"
+
+eslint-config-prettier@^8.5.0:
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
+  integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
 
 eslint-import-resolver-node@^0.3.6:
   version "0.3.6"
@@ -2155,24 +2179,25 @@ eslint-plugin-react-hooks@^4.5.0:
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==
 
 eslint-plugin-react@^7.31.7:
-  version "7.31.10"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz#6782c2c7fe91c09e715d536067644bbb9491419a"
-  integrity sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==
+  version "7.31.11"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz#011521d2b16dcf95795df688a4770b4eaab364c8"
+  integrity sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==
   dependencies:
-    array-includes "^3.1.5"
-    array.prototype.flatmap "^1.3.0"
+    array-includes "^3.1.6"
+    array.prototype.flatmap "^1.3.1"
+    array.prototype.tosorted "^1.1.1"
     doctrine "^2.1.0"
     estraverse "^5.3.0"
     jsx-ast-utils "^2.4.1 || ^3.0.0"
     minimatch "^3.1.2"
-    object.entries "^1.1.5"
-    object.fromentries "^2.0.5"
-    object.hasown "^1.1.1"
-    object.values "^1.1.5"
+    object.entries "^1.1.6"
+    object.fromentries "^2.0.6"
+    object.hasown "^1.1.2"
+    object.values "^1.1.6"
     prop-types "^15.8.1"
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
-    string.prototype.matchall "^4.0.7"
+    string.prototype.matchall "^4.0.8"
 
 eslint-scope@^7.1.1:
   version "7.1.1"
@@ -2664,6 +2689,13 @@ google-p12-pem@^4.0.0:
   integrity sha512-WPkN4yGtz05WZ5EhtlxNDWPhC4JIic6G8ePitwUWy4l+XPVYec+a0j0Ts47PDtW59y3RwAhUd9/h9ZZ63px6RQ==
   dependencies:
     node-forge "^1.3.1"
+
+gopd@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
+  integrity sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==
+  dependencies:
+    get-intrinsic "^1.1.3"
 
 graceful-fs@^4.1.9:
   version "4.2.10"
@@ -3195,17 +3227,17 @@ klona@^2.0.5:
   resolved "https://registry.yarnpkg.com/klona/-/klona-2.0.5.tgz#d166574d90076395d9963aa7a928fabb8d76afbc"
   integrity sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==
 
-language-subtag-registry@~0.3.2:
+language-subtag-registry@^0.3.20:
   version "0.3.22"
   resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"
   integrity sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==
 
 language-tags@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
-  integrity sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.6.tgz#c087cc42cd92eb71f0925e9e271d4f8be5a93430"
+  integrity sha512-HNkaCgM8wZgE/BZACeotAAgpL9FUjEnhgF0FVQMIgH//zqTPreLYMb3rWYkYAqPoF75Jwuycp1da7uz66cfFQg==
   dependencies:
-    language-subtag-registry "~0.3.2"
+    language-subtag-registry "^0.3.20"
 
 levn@^0.4.1:
   version "0.4.1"
@@ -3568,7 +3600,7 @@ object.assign@^4.1.3, object.assign@^4.1.4:
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
 
-object.entries@^1.1.5:
+object.entries@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.6.tgz#9737d0e5b8291edd340a3e3264bb8a3b00d5fa23"
   integrity sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==
@@ -3577,7 +3609,7 @@ object.entries@^1.1.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.fromentries@^2.0.5:
+object.fromentries@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/object.fromentries/-/object.fromentries-2.0.6.tgz#cdb04da08c539cffa912dcd368b886e0904bfa73"
   integrity sha512-VciD13dswC4j1Xt5394WR4MzmAQmlgN72phd/riNp9vtD7tp4QQWJ0R4wvclXcafgcYK8veHRed2W6XeGBvcfg==
@@ -3586,7 +3618,7 @@ object.fromentries@^2.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.hasown@^1.1.1:
+object.hasown@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.hasown/-/object.hasown-1.1.2.tgz#f919e21fad4eb38a57bc6345b3afd496515c3f92"
   integrity sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==
@@ -3594,7 +3626,7 @@ object.hasown@^1.1.1:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-object.values@^1.1.5:
+object.values@^1.1.5, object.values@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.6.tgz#4abbaa71eba47d63589d402856f908243eea9b1d"
   integrity sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==
@@ -4005,6 +4037,11 @@ regenerator-runtime@^0.13.10:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
   integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
 
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
 regexp.prototype.flags@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
@@ -4228,7 +4265,7 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.matchall@^4.0.7:
+string.prototype.matchall@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz#3bf85722021816dcd1bf38bb714915887ca79fd3"
   integrity sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==
@@ -4242,7 +4279,7 @@ string.prototype.matchall@^4.0.7:
     regexp.prototype.flags "^1.4.3"
     side-channel "^1.0.4"
 
-string.prototype.trimend@^1.0.5:
+string.prototype.trimend@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz#c4a27fa026d979d79c04f17397f250a462944533"
   integrity sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==
@@ -4251,7 +4288,7 @@ string.prototype.trimend@^1.0.5:
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
 
-string.prototype.trimstart@^1.0.5:
+string.prototype.trimstart@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz#e90ab66aa8e4007d92ef591bbf3cd422c56bdcf4"
   integrity sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,6 +1234,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-patch/-/json-patch-0.0.30.tgz#7c562173216c50529e70126ceb8e7a533f865e9b"
   integrity sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -1320,6 +1325,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/semver@^7.3.12":
+  version "7.3.13"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
+  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
+
 "@types/serve-static@*":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
@@ -1328,7 +1338,22 @@
     "@types/mime" "*"
     "@types/node" "*"
 
-"@typescript-eslint/parser@^5.42.0":
+"@typescript-eslint/eslint-plugin@^5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.0.tgz#9a96a713b9616c783501a3c1774c9e2b40217ad0"
+  integrity sha512-QrZqaIOzJAjv0sfjY4EjbXUi3ZOFpKfzntx22gPGr9pmFcTjcFw/1sS1LJhEubfAGwuLjNrPV0rH+D1/XZFy7Q==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.46.0"
+    "@typescript-eslint/type-utils" "5.46.0"
+    "@typescript-eslint/utils" "5.46.0"
+    debug "^4.3.4"
+    ignore "^5.2.0"
+    natural-compare-lite "^1.4.0"
+    regexpp "^3.2.0"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.42.0", "@typescript-eslint/parser@^5.46.0":
   version "5.46.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.46.0.tgz#002d8e67122947922a62547acfed3347cbf2c0b6"
   integrity sha512-joNO6zMGUZg+C73vwrKXCd8usnsmOYmgW/w5ZW0pG0RGvqeznjtGDk61EqqTpNrFLUYBW2RSBFrxdAZMqA4OZA==
@@ -1345,6 +1370,16 @@
   dependencies:
     "@typescript-eslint/types" "5.46.0"
     "@typescript-eslint/visitor-keys" "5.46.0"
+
+"@typescript-eslint/type-utils@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.46.0.tgz#3a4507b3b437e2fd9e95c3e5eea5ae16f79d64b3"
+  integrity sha512-dwv4nimVIAsVS2dTA0MekkWaRnoYNXY26dKz8AN5W3cBFYwYGFQEqm/cG+TOoooKlncJS4RTbFKgcFY/pOiBCg==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "5.46.0"
+    "@typescript-eslint/utils" "5.46.0"
+    debug "^4.3.4"
+    tsutils "^3.21.0"
 
 "@typescript-eslint/types@5.46.0":
   version "5.46.0"
@@ -1363,6 +1398,20 @@
     is-glob "^4.0.3"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/utils@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.46.0.tgz#600cd873ba471b7d8b0b9f35de34cf852c6fcb31"
+  integrity sha512-4O+Ps1CRDw+D+R40JYh5GlKLQERXRKW5yIQoNDpmXPJ+C7kaPF9R7GWl+PxGgXjB3PQCqsaaZUpZ9dG4U6DO7g==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.46.0"
+    "@typescript-eslint/types" "5.46.0"
+    "@typescript-eslint/typescript-estree" "5.46.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
+    semver "^7.3.7"
 
 "@typescript-eslint/visitor-keys@5.46.0":
   version "5.46.0"
@@ -2199,6 +2248,14 @@ eslint-plugin-react@^7.31.7:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-7.1.1.tgz#fff34894c2f65e5226d3041ac480b4513a163642"
@@ -2297,7 +2354,7 @@ esrecurse@^4.3.0:
   dependencies:
     estraverse "^5.2.0"
 
-estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
@@ -3488,6 +3545,11 @@ nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+natural-compare-lite@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
+  integrity sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
Close #5 

## 変更内容
- 以下を設定してauto fixを行った
  - prettier
    - 1行の文字数120文字
    - セミコロンの自動削除
  - eslint (flat config)
    - next/core-web-vitals
    - typescript-eslint/recommended
    - import/order
- GitHub Actionsの設定

VS CodeのEslint拡張機能ではflat configにまだ正式に対応してないので、使うなら拡張機能をpre-release版(v2.3)に変更して、`setting.json`に`"eslint.experimental.useFlatConfig": true`を追記する必要あり
これでいけるはずなんだけど、自分の環境では1回正常に動いた後動かなくなってしまった🥲